### PR TITLE
DO NOT MERGE: pageTemplate for forms question

### DIFF
--- a/src/http/form-get.ts
+++ b/src/http/form-get.ts
@@ -8,6 +8,7 @@ import {failureWithStatus} from '../types/failureWithStatus';
 import {oopsPage} from '../templates';
 import {sequenceS} from 'fp-ts/lib/Apply';
 import {Form} from '../types/form';
+import {pageTemplate} from '../templates';
 
 const getUser = (req: Request, deps: Dependencies) =>
   pipe(
@@ -27,12 +28,16 @@ export const formGet =
   async (req: Request, res: Response) => {
     await pipe(
       {
+        // chromy: User was computed here already:
         user: getUser(req, deps),
         events: deps.getAllEvents(),
       },
       sequenceS(TE.ApplyPar),
       TE.chainEitherK(form.constructForm({...req.query, ...req.params})),
       TE.map(form.renderForm),
+      //                              V How to pass it here?
+      TE.map(pageTemplate("thetitle", user)),
+      //
       TE.matchW(
         failure => {
           deps.logger.error(failure, 'Failed to show form to a user');


### PR DESCRIPTION
I was looking into converting the 'commands' pages (`formGet`) to use `pageTemplate` as done already by `queryGet`. This avoids every route having to apply the template itself.

I think I found the place where `pageTemplate` ought to be added. However I don't understand what the idiomatic way to thread a variable from earlier in the pipe is. @Lan2u @erkannt: any advice you have appreciated! XD