### PR TITLE
Env fixed so it doesn't prevent make dev

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 ADMIN_API_BEARER_TOKEN = secret
 GOOGLE_DB_URL = "file:/db/makespace-member-app-google.db"
-GOOGLE_SERVICE_ACCOUNT_KEY_JSON = disabled
+GOOGLE_SERVICE_ACCOUNT_KEY_JSON = {}
 LOG_LEVEL = info
 PUBLIC_URL = http://localhost:8080
 SESSION_SECRET = session-secret


### PR DESCRIPTION
'disabled' causes a json error which prevents sync worker starting. This then prevents the sync metadata table being created which then prevents visiting certain pages (equipment pages) when running `make dev`

This was one of the issues raised when we did that onboarding session