### PR TITLE
Set isolatedModules in tsconfig.json

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -7,7 +7,6 @@ module.exports = {
       'ts-jest',
       {
         diagnostics: false,
-        isolatedModules: true,
       },
     ],
   },

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -19,5 +19,5 @@ export const sendEmailCommands = {
   ownerAgreementInvite,
 };
 
-export {Command} from './command';
-export {SendEmail} from './send-email';
+export type {Command} from './command';
+export type {SendEmail} from './send-email';

--- a/src/queries/index.ts
+++ b/src/queries/index.ts
@@ -17,4 +17,4 @@ export {dumpSharedDbAsJson, dumpSharedDbAsBuffer} from './debug';
 export {domainEvents} from './domain-events';
 export {troubleTickets} from './trouble-tickets';
 export {logGoogleJson} from './log-google';
-export {Query} from './query';
+export type {Query} from './query';

--- a/src/read-models/members/index.ts
+++ b/src/read-models/members/index.ts
@@ -9,5 +9,5 @@ export const members = {
   getFailedImports,
 };
 
-export {FailedLinking} from './failed-linking';
-export {Member} from './return-types';
+export type {FailedLinking} from './failed-linking';
+export type {Member} from './return-types';

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,15 +1,18 @@
-export {EmailAddress, EmailAddressCodec} from './email-address';
-export {Failure, failure} from './failure';
-export {Email} from './email';
+export type {EmailAddress} from './email-address';
+export {EmailAddressCodec} from './email-address';
+export type {Failure} from './failure';
+export {failure} from './failure';
+export type {Email} from './email';
 export {User} from './user';
 export {Actor} from './actor';
 export {HttpResponse} from './html';
-export {GravatarHash, isoGravatarHash} from './gravatar-hash';
+export type {GravatarHash} from './gravatar-hash';
+export {isoGravatarHash} from './gravatar-hash';
 export {
   DomainEvent,
   isEventOfType,
   constructEvent,
-  SubsetOfDomainEvent,
   filterByName,
 } from './domain-event';
-export {ResourceVersion} from './resource-version';
+export type {SubsetOfDomainEvent} from './domain-event';
+export type {ResourceVersion} from './resource-version';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,8 @@
     "forceConsistentCasingInFileNames": true,
     "composite": true,
     "allowUnusedLabels": false,
-    "allowUnreachableCode": false
+    "allowUnreachableCode": false,
+    "isolatedModules": true
   },
   "include": [
     "src/**/*.ts",


### PR DESCRIPTION
This silences the warnings of the form:
```
ts-jest[config] (WARN)
    The "ts-jest" config option "isolatedModules" is deprecated and will be removed in v30.0.0. Please use "isolatedModules: true" in /[...]/members-app/tsconfig.json instead, see https://www.typescriptlang.org/tsconfig/#isolatedModules
```
