### PR TITLE
Prevent failed event duplication

### DIFF
--- a/src/read-models/shared-state/state.ts
+++ b/src/read-models/shared-state/state.ts
@@ -222,6 +222,8 @@ export const failedEventsTable = sqliteTable(
   'failedEventsTable',
   {
     error: text('error').notNull(),
+    eventId: text('eventId').unique().notNull(),
+    eventIndex: integer('eventIndex').notNull(),
     payload: text('payload', {mode: 'json'}).notNull(),
   }
 );
@@ -229,6 +231,8 @@ export const failedEventsTable = sqliteTable(
 const createFailedEventsTable = sql`
   CREATE TABLE IF NOT EXISTS failedEventsTable (
     error TEXT NOT NULL,
+    eventId TEXT NOT NULL UNIQUE,
+    eventIndex INTEGER NOT NULL,
     payload TEXT NOT NULL
   )
 `;

--- a/src/read-models/shared-state/update-state.ts
+++ b/src/read-models/shared-state/update-state.ts
@@ -578,6 +578,8 @@ export function updateState (db: BetterSQLite3Database, logger: Logger, trackedE
         db.transaction((tx: DatabaseTransaction) => {
           tx.insert(failedEventsTable)
             .values({
+              eventId: event.event_id,
+              eventIndex: event.event_index,
               error: reason,
               payload: event,
             })

--- a/tests/read-models/shared-state/failed-events.test.ts
+++ b/tests/read-models/shared-state/failed-events.test.ts
@@ -63,6 +63,22 @@ describe('failed-events', () => {
     );
   });
 
+  it("doesn't duplicate a failed event when applied more than once", () => {
+    const failedEvent = framework.insertIntoSharedReadModel(
+      arbitraryFailingOwnerAddedEvent()
+    );
+
+    framework.sharedReadModel.updateState(failedEvent);
+
+    const rows = framework.sharedReadModel.db
+      .select()
+      .from(failedEventsTable)
+      .all();
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0].eventId).toStrictEqual(failedEvent.event_id);
+  });
+
   it('continues applying later tracked events after a failure', () => {
     framework.insertIntoSharedReadModel(arbitraryFailingOwnerAddedEvent());
     const successfulEvent = framework.insertIntoSharedReadModel(


### PR DESCRIPTION
Otherwise the events just keep getting duplicated everytime the sharedReadModel is rebuilt