### PR TITLE
fixed redirect for after Owner Agreement

### DIFF
--- a/src/commands/members/sign-owner-agreement-form.ts
+++ b/src/commands/members/sign-owner-agreement-form.ts
@@ -12,7 +12,7 @@ const renderForm = (viewModel: ViewModel) =>
     html`
       <h1>Sign the Owner Agreement</h1>
       ${ownerAgreement}
-      <form action="#" method="post">
+      <form action="?next=/me" method="post">
         <input
           type="hidden"
           name="memberNumber"

--- a/tests/commands/members/sign-owner-agreement-form.test.ts
+++ b/tests/commands/members/sign-owner-agreement-form.test.ts
@@ -1,0 +1,19 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import {signOwnerAgreementForm} from '../../../src/commands/members/sign-owner-agreement-form';
+import {arbitraryUser} from '../../types/user.helper';
+
+describe('sign owner agreement form', () => {
+  it('redirects signing members to /me on success so non-admins do not land on the admin-only /members page', () => {
+    const rendered = signOwnerAgreementForm.renderForm({user: arbitraryUser()});
+
+    const body = document.createElement('body');
+    body.innerHTML = rendered.body;
+
+    const form = body.querySelector<HTMLFormElement>('form');
+
+    expect(form!.getAttribute('action')).toStrictEqual('?next=/me');
+  });
+});

--- a/tests/http/form-post.test.ts
+++ b/tests/http/form-post.test.ts
@@ -1,0 +1,79 @@
+import {Request, Response} from 'express';
+import * as TE from 'fp-ts/TaskEither';
+import * as O from 'fp-ts/Option';
+import * as t from 'io-ts';
+import {StatusCodes} from 'http-status-codes';
+import {formPost} from '../../src/http/form-post';
+import {Dependencies} from '../../src/dependencies';
+import {Command} from '../../src/commands';
+import {CompleteHtmlDocument} from '../../src/types/html';
+import {arbitraryUser} from '../types/user.helper';
+
+const alwaysOkCommand: Command<Record<string, never>> = {
+  decode: t.strict({}).decode,
+  isAuthorized: () => true,
+  resource: () => ({type: 'Test', id: 'x'}),
+  process: () => TE.right(O.none),
+};
+
+const makeDeps = (): Dependencies =>
+  ({
+    logger: {error: jest.fn(), debug: jest.fn()},
+    getAllEvents: () => TE.right([]),
+    getResourceEvents: () => TE.right({events: [], version: 0}),
+    commitEvent: () => () =>
+      TE.right({status: StatusCodes.CREATED, message: ''}),
+    sharedReadModel: {},
+  }) as unknown as Dependencies;
+
+const makeReq = (query: Record<string, unknown>): Request =>
+  ({
+    session: {passport: {user: arbitraryUser()}},
+    body: {},
+    query,
+  }) as unknown as Request;
+
+type FakeResponse = Response<CompleteHtmlDocument> & {
+  redirect: jest.Mock;
+  status: jest.Mock;
+  send: jest.Mock;
+};
+
+const makeRes = (): FakeResponse =>
+  ({
+    redirect: jest.fn(),
+    status: jest.fn().mockReturnThis(),
+    send: jest.fn().mockReturnThis(),
+  }) as unknown as FakeResponse;
+
+describe('formPost redirect on success', () => {
+  it('falls back to the provided successTarget when no ?next= query param is present', async () => {
+    const res = makeRes();
+
+    await formPost(makeDeps(), alwaysOkCommand, '/members')(makeReq({}), res);
+
+    expect(res.redirect).toHaveBeenCalledWith('/members');
+  });
+
+  it('honours a ?next= path so a non-admin signing the owner agreement is sent to /me rather than the admin-only /members page', async () => {
+    const res = makeRes();
+
+    await formPost(makeDeps(), alwaysOkCommand, '/members')(
+      makeReq({next: '/me'}),
+      res
+    );
+
+    expect(res.redirect).toHaveBeenCalledWith('/me');
+  });
+
+  it('ignores a ?next= value that is not a path and falls back to the successTarget', async () => {
+    const res = makeRes();
+
+    await formPost(makeDeps(), alwaysOkCommand, '/members')(
+      makeReq({next: 'https://evil.example.com'}),
+      res
+    );
+
+    expect(res.redirect).toHaveBeenCalledWith('/members');
+  });
+});


### PR DESCRIPTION
fixed redirect for after Owner Agreement submission to go to /me rater than /members which is only accessible for admins/superusers. Created matching tests

Users were previously experiencing 403 errors