### PR TITLE
Match login emails case-insensitively (#260)

### DIFF
--- a/scripts/populate-local-dev.sh
+++ b/scripts/populate-local-dev.sh
@@ -49,3 +49,7 @@ event 'api/members/edit-forms-of-address' '{"memberNumber": "9999", "formsOfAddr
 
 # foo@example.com
 event 'api/members/create' '{"memberNumber": "1234", "email": "foo@example.com"}'
+
+# Mixed-case local part (for testing case-insensitive email login, issue #260)
+# Stored as "Joe@example.com"; logging in with "joe@example.com" should still work.
+event 'api/members/create' '{"memberNumber": "4321", "email": "Joe@example.com"}'

--- a/src/authentication/login/send-log-in-link.ts
+++ b/src/authentication/login/send-log-in-link.ts
@@ -5,7 +5,6 @@ import {Email, EmailAddress, Failure, failure} from '../../types';
 import {Config} from '../../configuration';
 import {magicLink} from '..';
 import mjml2html from 'mjml';
-import {normaliseEmailAddress} from '../../read-models/shared-state/normalise-email-address';
 import * as O from 'fp-ts/Option';
 
 const toEmail =
@@ -46,26 +45,24 @@ export const sendLogInLink = (
   deps: Pick<Dependencies, 'sendEmail' | 'rateLimitSendingOfEmails' | 'sharedReadModel' | 'logger'>,
   conf: Config
 ) => (emailAddress: EmailAddress): TE.TaskEither<Failure, string> => {
-  const member = deps.sharedReadModel.members.getByEmail(emailAddress, true);
-  if (O.isNone(member)) {
+  // Match the typed email to a stored one case-insensitively (e.g. "joe@x.com"
+  // finds a member registered as "Joe@x.com"). resolveEmailForLogin returns the
+  // address exactly as stored, so we always send to the on-file casing.
+  const storedEmail = deps.sharedReadModel.members.resolveEmailForLogin(
+    emailAddress,
+    true
+  );
+  if (O.isNone(storedEmail)) {
     return TE.left(failure('No member associated with that email')());
   }
-  const matchedEmail = pipe(
-    member.value.emails,
-    emails =>
-      emails.find(
-        memberEmail =>
-          memberEmail.emailAddress === normaliseEmailAddress(emailAddress)
-      ),
-    O.fromNullable,
-    O.getOrElseW(() => {
-      throw new Error('Expected matched verified email to be present on member');
-    }),
-    email => email.emailAddress
-  );
   // Note that we intentionally use the stored email address rather than the one provided.
   // This prevents attacks where you specify an email address that somehow matches to an existing user but isn't
   // actually treated the same by the mailserver(s) so gets routed differently (to the attacker).
+  const matchedEmail = storedEmail.value;
+  const member = deps.sharedReadModel.members.getByEmail(matchedEmail, true);
+  if (O.isNone(member)) {
+    return TE.left(failure('No member associated with that email')());
+  }
   const email = toEmail(matchedEmail)(
     magicLink.create(conf)({
       emailAddress: matchedEmail,

--- a/src/read-models/shared-state/index.ts
+++ b/src/read-models/shared-state/index.ts
@@ -31,7 +31,7 @@ import { ReadonlyRecord } from 'fp-ts/lib/ReadonlyRecord';
 import { TrainingSheetId } from '../../types/training-sheet';
 import { EquipmentId } from '../../types/equipment-id';
 import { getTrainingSheetIdMapping } from './equipment/get';
-import { findAllSuperUsers, findUserIdByEmail, findUserIdByMemberNumber, getAllMemberCore } from './member/get';
+import { findAllSuperUsers, findStoredEmailForLogin, findUserIdByEmail, findUserIdByMemberNumber, getAllMemberCore } from './member/get';
 import { setupEventStateTable } from './setup-event-state-table';
 import { getCurrentEventIndex } from './get-current-event-index';
 import { Int } from 'io-ts';
@@ -49,6 +49,10 @@ export type SharedReadModel = {
     getById: (userId: UserId) => O.Option<Member>;
     getByMemberNumber: (memberNumber: number) => O.Option<Member>;
     getByEmail: (email: EmailAddress, mustBeVerified: boolean) => O.Option<Member>;
+    resolveEmailForLogin: (
+      email: EmailAddress,
+      mustBeVerified: boolean
+    ) => O.Option<EmailAddress>;
     getAll: () => ReadonlyArray<Member>;
     getAllCore: () => ReadonlyArray<MemberCoreInfo>;
     getAsActor: (user: User) => (memberNumber: number) => O.Option<Member>;
@@ -101,6 +105,7 @@ export const initSharedReadModel = (
     members: {
       getByMemberNumber: getMemberFullByMemberNumber(readModelDb),
       getByEmail: getMemberFullByEmail(readModelDb),
+      resolveEmailForLogin: findStoredEmailForLogin(readModelDb),
       getById: getMemberFullByUserId(readModelDb),
       getAll: getAllMemberFull(readModelDb),
       getAllCore: () => getAllMemberCore(readModelDb),

--- a/src/read-models/shared-state/member/get.ts
+++ b/src/read-models/shared-state/member/get.ts
@@ -1,6 +1,6 @@
 import {pipe} from 'fp-ts/lib/function';
 import {BetterSQLite3Database} from 'drizzle-orm/better-sqlite3';
-import {and, desc, eq, isNotNull} from 'drizzle-orm';
+import {and, desc, eq, isNotNull, sql} from 'drizzle-orm';
 import * as O from 'fp-ts/Option';
 import * as RA from 'fp-ts/ReadonlyArray';
 import {MemberCoreInfo, MemberEmail} from '../return-types';
@@ -81,6 +81,44 @@ export const findUserIdByEmail =
       .get(),
     row => O.fromNullable(row?.userId)
   );
+
+// Resolves the email a user typed at login to the email address as *stored* in
+// the system, matching case-insensitively. The caller then sends the login link
+// to the returned (stored) address rather than the typed one.
+//
+// This is deliberately separate from findUserIdByEmail (which stays an exact
+// match) so that only the login lookup is case-insensitive - the event
+// projection and linking commands must keep matching exactly, otherwise two
+// genuinely-distinct members differing only by capitalisation could be merged.
+export const findStoredEmailForLogin =
+  (db: BetterSQLite3Database) =>
+  (email: EmailAddress, mustBeVerified: boolean): O.Option<EmailAddress> => {
+    const matchesIgnoringCase = sql`lower(${memberEmailsTable.emailAddress}) = ${email.toLowerCase()}`;
+    const storedEmails = db
+      .select({emailAddress: memberEmailsTable.emailAddress})
+      .from(memberEmailsTable)
+      .where(
+        mustBeVerified
+          ? and(matchesIgnoringCase, isNotNull(memberEmailsTable.verifiedAt))
+          : matchesIgnoringCase
+      )
+      .all()
+      .map(row => row.emailAddress);
+
+    const distinct = [...new Set(storedEmails)] as ReadonlyArray<EmailAddress>;
+
+    if (distinct.length <= 1) {
+      return O.fromNullable(distinct[0]);
+    }
+
+    // More than one member shares this email address, differing only by
+    // capitalisation. This is extremely rare, but to avoid sending a login link
+    // to the wrong person we fall back to requiring an exact match
+    // (case-sensitive on the local part; the domain is always case-insensitive).
+    return O.fromNullable(
+      distinct.find(stored => stored === normaliseEmailAddress(email))
+    );
+  };
 
 export const getMemberCoreByUserId =
   (db: BetterSQLite3Database) =>

--- a/tests/authentication/send-login-link.test.ts
+++ b/tests/authentication/send-login-link.test.ts
@@ -262,6 +262,106 @@ describe('send-log-in-link', () => {
     );
   });
 
+  // Issue #260: the local-part of an email (before the @) was compared
+  // case-sensitively, so a member stored as "Joe@x.com" could not log in by
+  // typing "joe@x.com" and silently received no link. Matching is now
+  // case-insensitive, but the link is always sent to the stored address.
+  describe('when the typed email differs from the stored one only by local-part casing', () => {
+    describe('member registered with a lowercase local part', () => {
+      const storedEmail = 'joe@example.com' as EmailAddress;
+
+      beforeEach(async () => {
+        await framework.commands.memberNumbers.linkNumberToEmail({
+          email: storedEmail,
+          memberNumber: faker.number.int(),
+          name: undefined,
+          formOfAddress: undefined,
+        });
+      });
+
+      it('logs in with an uppercased local part and sends to the stored address', async () => {
+        const result = getRightOrFail(
+          await sendLogInLink(deps, conf)('Joe@example.com' as EmailAddress)()
+        );
+        expect(deps.sendEmail).toHaveBeenCalledWith(
+          expect.objectContaining({recipient: storedEmail})
+        );
+        expect(result).toStrictEqual(`Sent login link to ${storedEmail}`);
+      });
+    });
+
+    describe('member registered with a capitalised local part (e.g. Google Forms auto-capitalisation)', () => {
+      const storedEmail = 'Joe@example.com' as EmailAddress;
+
+      beforeEach(async () => {
+        await framework.commands.memberNumbers.linkNumberToEmail({
+          email: storedEmail,
+          memberNumber: faker.number.int(),
+          name: undefined,
+          formOfAddress: undefined,
+        });
+      });
+
+      it('logs in with a lowercased local part but still sends to the stored (capitalised) address', async () => {
+        const result = getRightOrFail(
+          await sendLogInLink(deps, conf)('joe@example.com' as EmailAddress)()
+        );
+        expect(deps.sendEmail).toHaveBeenCalledWith(
+          expect.objectContaining({recipient: storedEmail})
+        );
+        expect(result).toStrictEqual(`Sent login link to ${storedEmail}`);
+      });
+    });
+  });
+
+  // If two distinct members have emails differing only by local-part casing, a
+  // case-insensitive match is ambiguous - matching either one risks sending a
+  // login link (and thus account access) to the wrong person. In that case we
+  // fall back to requiring an exact match, and send nothing if none matches.
+  describe('when two members share an email differing only by local-part casing', () => {
+    const lowerEmail = 'sam@example.com' as EmailAddress;
+    const upperEmail = 'Sam@example.com' as EmailAddress;
+
+    beforeEach(async () => {
+      await framework.commands.memberNumbers.linkNumberToEmail({
+        email: lowerEmail,
+        memberNumber: faker.number.int(),
+        name: undefined,
+        formOfAddress: undefined,
+      });
+      await framework.commands.memberNumbers.linkNumberToEmail({
+        email: upperEmail,
+        memberNumber: faker.number.int(),
+        name: undefined,
+        formOfAddress: undefined,
+      });
+    });
+
+    it('sends to the exact match when the typed casing matches one exactly', async () => {
+      const result = getRightOrFail(
+        await sendLogInLink(deps, conf)(upperEmail)()
+      );
+      expect(deps.sendEmail).toHaveBeenCalledWith(
+        expect.objectContaining({recipient: upperEmail})
+      );
+      expect(result).toStrictEqual(`Sent login link to ${upperEmail}`);
+    });
+
+    it('does not send a link when the typed casing matches neither exactly', async () => {
+      const result = await sendLogInLink(deps, conf)(
+        'SAM@example.com' as EmailAddress
+      )();
+      expect(result).toStrictEqual(
+        E.left(
+          expect.objectContaining({
+            message: 'No member associated with that email',
+          })
+        )
+      );
+      expect(deps.sendEmail).not.toHaveBeenCalled();
+    });
+  });
+
   describe('when no member are setup', () => {
     let result: E.Either<Failure, string>;
 


### PR DESCRIPTION
Closes #260

## Problem

The local-part of an email (before the `@`) was compared **case-sensitively** at login, so a member stored as `Joe@example.com` could not log in by typing `joe@example.com` — they silently received no magic link (the request still returns the normal "check your mail" response, so it fails invisibly).

This affects real logins: in practice every major email provider treats the local-part case-insensitively, and many members' addresses were auto-capitalised (e.g. by Google Forms) when first recorded.

Note the domain was *already* matched case-insensitively; this extends the same treatment to the local part.

## Change

- Login lookup now matches the typed email against stored emails **case-insensitively**, but the magic link is still sent to the address **exactly as stored** — preserving the existing anti-spoofing behaviour (we never deliver to an attacker-supplied casing).
- In the rare case where two members' emails differ **only** by capitalisation, a case-insensitive match is ambiguous, so we **fall back to requiring an exact match** and send nothing if none matches — a login link is never sent to the wrong person.

## Implementation notes

- Implemented as a new **login-only** resolver (`findStoredEmailForLogin` → exposed as `members.resolveEmailForLogin`). `findUserIdByEmail` stays an **exact** match, so the event projection and linking commands are unaffected and two genuinely-distinct members can't be merged.
- **No data migration needed:** the read model is rebuilt from events on startup, so existing members become matchable immediately.

## Tests

Added coverage to `tests/authentication/send-login-link.test.ts`:
- registered lowercase + typed uppercase → link sent to the stored address
- registered capitalised (the Google Forms case) + typed lowercase → link sent to the stored (capitalised) address
- two members colliding on casing: exact-casing login reaches the right member; a third casing matching neither sends nothing

All 21 tests in the file pass; typecheck clean. Also verified end-to-end against a local `make dev` instance via Mailcatcher.

🤖 Generated with [Claude Code](https://claude.com/claude-code)