### PR TITLE
Make areas page accessible to non-superusers

### DIFF
--- a/src/queries/areas/construct-view-model.ts
+++ b/src/queries/areas/construct-view-model.ts
@@ -5,7 +5,6 @@ import * as E from 'fp-ts/Either';
 import * as O from 'fp-ts/Option';
 import {FailureWithStatus} from '../../types/failure-with-status';
 import {AreaViewModel, OwnerViewModel, ViewModel} from './view-model';
-import {mustBeSuperuser} from '../util';
 import {ExternalStateDB} from '../../sync-worker/external-state-db';
 import {
   getRecurlyReasonsForMember,
@@ -53,11 +52,14 @@ export const constructViewModel =
   (sharedReadModel: Dependencies['sharedReadModel'], extDB: ExternalStateDB) =>
   (user: User): TE.TaskEither<FailureWithStatus, ViewModel> =>
   async () => {
-    const superUserCheck = await mustBeSuperuser(sharedReadModel, user)();
-    if (E.isLeft(superUserCheck)) {
-      return superUserCheck;
-    }
+    const member = sharedReadModel.members.getByMemberNumber(user.memberNumber);
+    const isSuperUser = O.isSome(member) && member.value.isSuperUser;
+    const isOwnerOfAnyArea =
+      O.isSome(member) && member.value.ownerOf.length > 0;
+
     return E.right({
+      canManageAreas: isSuperUser,
+      canSeeOwnerPrivateDetails: isSuperUser || isOwnerOfAnyArea,
       areas: await Promise.all(
         sharedReadModel.area.getAll().map(expandArea(sharedReadModel, extDB))
       ),

--- a/src/queries/areas/construct-view-model.ts
+++ b/src/queries/areas/construct-view-model.ts
@@ -3,7 +3,10 @@ import {Dependencies} from '../../dependencies';
 import * as TE from 'fp-ts/TaskEither';
 import * as E from 'fp-ts/Either';
 import * as O from 'fp-ts/Option';
-import {FailureWithStatus} from '../../types/failure-with-status';
+import {
+  failureWithStatus,
+  FailureWithStatus,
+} from '../../types/failure-with-status';
 import {AreaViewModel, OwnerViewModel, ViewModel} from './view-model';
 import {ExternalStateDB} from '../../sync-worker/external-state-db';
 import {
@@ -12,6 +15,7 @@ import {
   RecurlyReason,
 } from '../../read-models/external-state/recurly-status';
 import {Area, Owner} from '../../read-models/shared-state/return-types';
+import {StatusCodes} from 'http-status-codes';
 
 const NO_RECURLY_DATA: {
   flags: O.Option<RecurlyFlags>;
@@ -53,9 +57,17 @@ export const constructViewModel =
   (user: User): TE.TaskEither<FailureWithStatus, ViewModel> =>
   async () => {
     const member = sharedReadModel.members.getByMemberNumber(user.memberNumber);
-    const isSuperUser = O.isSome(member) && member.value.isSuperUser;
-    const isOwnerOfAnyArea =
-      O.isSome(member) && member.value.ownerOf.length > 0;
+    if (O.isNone(member)) {
+      return E.left(
+        failureWithStatus(
+          'Cannot find sufficient information about you to determine if you can access this page',
+          StatusCodes.UNAUTHORIZED
+        )()
+      );
+    }
+
+    const isSuperUser = member.value.isSuperUser;
+    const isOwnerOfAnyArea = member.value.ownerOf.length > 0;
 
     return E.right({
       canManageAreas: isSuperUser,

--- a/src/queries/areas/index.ts
+++ b/src/queries/areas/index.ts
@@ -10,5 +10,5 @@ export const areas: Query = deps => user =>
     user,
     constructViewModel(deps.sharedReadModel, deps.extDB),
     TE.map(render),
-    TE.map(toLoggedInContent(safe('Manage Areas and Owners')))
+    TE.map(toLoggedInContent(safe('Areas')))
   );

--- a/src/queries/areas/render.ts
+++ b/src/queries/areas/render.ts
@@ -97,8 +97,8 @@ const renderActiveOwners = (
     <table>
       <thead>
         <tr>
-          <th>Member Number</th>
-          <th>Name</th>
+          <th>Owner Member Number</th>
+          <th>Owner Name</th>
           ${canSeeOwnerPrivateDetails ? html`<th>Email</th>` : html``}
           ${canSeeOwnerPrivateDetails
             ? html`<th>Agreement Signed</th>`

--- a/src/queries/areas/render.ts
+++ b/src/queries/areas/render.ts
@@ -183,6 +183,9 @@ const renderArea =
   (area: AreaViewModel) => {
   const activeOwners = area.owners.filter(owner => owner.isActiveOwner);
   const inactiveOwners = area.owners.filter(owner => !owner.isActiveOwner);
+  const publiclyVisibleOwners = viewModel.canManageAreas
+    ? activeOwners
+    : area.owners;
   return html`
   <article id="area-${safe(area.id)}">
     <h2>${sanitizeString(area.name)}</h2>
@@ -192,8 +195,8 @@ const renderArea =
     <div>${renderEquipment(area.equipment)}</div>
     ${renderActiveOwners(
       area.id,
-      activeOwners,
-      inactiveOwners.length > 0,
+      publiclyVisibleOwners,
+      viewModel.canManageAreas && inactiveOwners.length > 0,
       viewModel.canManageAreas,
       viewModel.canSeeOwnerPrivateDetails
     )}

--- a/src/queries/areas/render.ts
+++ b/src/queries/areas/render.ts
@@ -24,6 +24,13 @@ const renderSignedAt = (owner: Owner) => {
   if (O.isSome(owner.agreementSigned)) {
     return pipe(owner.agreementSigned.value, DateTime.fromJSDate, displayDate);
   }
+  return html`Not signed`;
+};
+
+const renderSignedAtForManager = (owner: Owner) => {
+  if (O.isSome(owner.agreementSigned)) {
+    return renderSignedAt(owner);
+  }
   return html`
     <form action="/send-email/owner-agreement-invite" method="post">
       <input type="hidden" name="recipient" value="${owner.memberNumber}" />
@@ -47,22 +54,32 @@ const renderRemoveOwner = (
 const ownerRow = (
   areaId: Area['id'],
   owner: OwnerViewModel,
+  canManageAreas: boolean,
+  canSeeOwnerPrivateDetails: boolean,
   reasonCell: Html = html``
 ) => html`
   <tr>
     <td>${renderMemberNumber(owner.memberNumber)}</td>
     <td>${sanitizeString(O.getOrElse(() => '-')(owner.name))}</td>
-    <td>${safe(owner.primaryEmailAddress)}</td>
-    ${reasonCell}
-    <td>${renderSignedAt(owner)}</td>
-    <td>${renderRemoveOwner(areaId, owner)}</td>
+    ${canSeeOwnerPrivateDetails
+      ? html`<td>${safe(owner.primaryEmailAddress)}</td>`
+      : html``}
+    ${canManageAreas ? reasonCell : html``}
+    ${canSeeOwnerPrivateDetails
+      ? html`<td>${
+          canManageAreas ? renderSignedAtForManager(owner) : renderSignedAt(owner)
+        }</td>`
+      : html``}
+    ${canManageAreas ? html`<td>${renderRemoveOwner(areaId, owner)}</td>` : html``}
   </tr>
 `;
 
 const renderActiveOwners = (
   areaId: Area['id'],
   owners: ReadonlyArray<OwnerViewModel>,
-  hasInactiveOwners: boolean
+  hasInactiveOwners: boolean,
+  canManageAreas: boolean,
+  canSeeOwnerPrivateDetails: boolean
 ) => {
   if (owners.length === 0) {
     return hasInactiveOwners
@@ -75,13 +92,24 @@ const renderActiveOwners = (
         <tr>
           <th>Member Number</th>
           <th>Name</th>
-          <th>Email</th>
-          <th>Agreement Signed</th>
-          <th></th>
+          ${canSeeOwnerPrivateDetails ? html`<th>Email</th>` : html``}
+          ${canSeeOwnerPrivateDetails
+            ? html`<th>Agreement Signed</th>`
+            : html``}
+          ${canManageAreas ? html`<th></th>` : html``}
         </tr>
       </thead>
       <tbody>
-        ${joinHtml(owners.map(owner => ownerRow(areaId, owner)))}
+        ${joinHtml(
+          owners.map(owner =>
+            ownerRow(
+              areaId,
+              owner,
+              canManageAreas,
+              canSeeOwnerPrivateDetails
+            )
+          )
+        )}
       </tbody>
     </table>
   `;
@@ -89,9 +117,10 @@ const renderActiveOwners = (
 
 const renderInactiveOwners = (
   areaId: Area['id'],
-  owners: ReadonlyArray<OwnerViewModel>
+  owners: ReadonlyArray<OwnerViewModel>,
+  canManageAreas: boolean
 ) => {
-  if (owners.length === 0) {
+  if (!canManageAreas || owners.length === 0) {
     return html``;
   }
   return html`
@@ -114,6 +143,8 @@ const renderInactiveOwners = (
               ownerRow(
                 areaId,
                 owner,
+                canManageAreas,
+                true,
                 html`<td>${renderReasonChips(owner.reasons)}</td>`
               )
             )
@@ -124,30 +155,44 @@ const renderInactiveOwners = (
   `;
 };
 
-const renderEquipment = (equipment: ReadonlyArray<Equipment>) =>
-  pipe(
+const renderEquipment = (equipment: ReadonlyArray<Equipment>) => {
+  if (equipment.length === 0) {
+    return html`<p>No equipment currently assigned to this area.</p>`;
+  }
+
+  return pipe(
     equipment,
     RA.map(
       item => html`
         <a href="/equipment/${safe(item.id)}">${sanitizeString(item.name)}</a>
       `
     ),
-    items => html`RED equipment: ${commaHtml(items)}`
+    items => html`<p><strong>RED equipment:</strong> ${commaHtml(items)}</p>`
   );
+};
 
-const renderArea = (area: AreaViewModel) => {
+const renderArea =
+  (viewModel: ViewModel) =>
+  (area: AreaViewModel) => {
   const activeOwners = area.owners.filter(owner => owner.isActiveOwner);
   const inactiveOwners = area.owners.filter(owner => !owner.isActiveOwner);
   return html`
-  <article>
+  <article id="area-${safe(area.id)}">
     <h2>${sanitizeString(area.name)}</h2>
     ${O.isSome(area.email)
       ? html`<p><strong>Mailing list:</strong> ${safe(area.email.value)}</p>`
       : html``}
     <div>${renderEquipment(area.equipment)}</div>
-    ${renderActiveOwners(area.id, activeOwners, inactiveOwners.length > 0)}
-    ${renderInactiveOwners(area.id, inactiveOwners)}
-    <div class="wrap">
+    ${renderActiveOwners(
+      area.id,
+      activeOwners,
+      inactiveOwners.length > 0,
+      viewModel.canManageAreas,
+      viewModel.canSeeOwnerPrivateDetails
+    )}
+    ${renderInactiveOwners(area.id, inactiveOwners, viewModel.canManageAreas)}
+    ${
+      viewModel.canManageAreas ? html`<div class="wrap">
       <a class="button" href="/areas/add-owner?area=${safe(area.id)}"
         >Add owner</a
       >
@@ -160,16 +205,17 @@ const renderArea = (area: AreaViewModel) => {
       <a class="button" href="/areas/remove?area=${safe(area.id)}"
         >Remove area</a
       >
-    </div>
+    </div>` : html``
+    }
   </article>
 `;
 };
 
-const renderAreas = (areas: ViewModel['areas']) => {
-  if (areas.length === 0) {
+const renderAreas = (viewModel: ViewModel) => {
+  if (viewModel.areas.length === 0) {
     return html`<p>Currently no Areas</p> `;
   }
-  return pipe(areas, RA.map(renderArea), joinHtml);
+  return pipe(viewModel.areas, RA.map(renderArea(viewModel)), joinHtml);
 };
 
 const addAreaCallToAction = html`
@@ -178,8 +224,8 @@ const addAreaCallToAction = html`
 
 export const render = (viewModel: ViewModel) => html`
   <div class="stack-large">
-    <h1>Manage Areas and Owners</h1>
-    <div>${addAreaCallToAction}</div>
-    <section class="stack-large">${renderAreas(viewModel.areas)}</section>
+    <h1>Areas</h1>
+    ${viewModel.canManageAreas ? html`<div>${addAreaCallToAction}</div>` : html``}
+    <section class="stack-large">${renderAreas(viewModel)}</section>
   </div>
 `;

--- a/src/queries/areas/render.ts
+++ b/src/queries/areas/render.ts
@@ -82,6 +82,13 @@ const renderActiveOwners = (
   canSeeOwnerPrivateDetails: boolean
 ) => {
   if (owners.length === 0) {
+    if (!canManageAreas) {
+      return html`<p>
+        This area doesn't have any owners currently - email
+        owners@makespace.org to get involved!
+      </p>`;
+    }
+
     return hasInactiveOwners
       ? html` <p>No active owners — see inactive owners below.</p> `
       : html` <p>Owners needed!</p> `;

--- a/src/queries/areas/view-model.ts
+++ b/src/queries/areas/view-model.ts
@@ -16,4 +16,6 @@ export type AreaViewModel = Omit<Area, 'owners'> & {
 
 export type ViewModel = {
   areas: ReadonlyArray<AreaViewModel>;
+  canManageAreas: boolean;
+  canSeeOwnerPrivateDetails: boolean;
 };

--- a/src/queries/equipment/render.ts
+++ b/src/queries/equipment/render.ts
@@ -364,7 +364,10 @@ export const render = (viewModel: ViewModel) =>
       <div class="stack">
         <h1>${sanitizeString(viewModel.equipment.name)}</h1>
         <p>
-          <strong>Area:</strong> ${sanitizeString(viewModel.equipment.area.name)}
+          <strong>Area:</strong>
+          <a href="/areas#area-${safe(viewModel.equipment.area.id)}">
+            ${sanitizeString(viewModel.equipment.area.name)}
+          </a>
           ${O.isSome(viewModel.equipment.area.email)
             ? html` | <strong>Mailing list:</strong>
               ${safe(viewModel.equipment.area.email.value)}`

--- a/src/queries/training-matrix/construct-view-model.ts
+++ b/src/queries/training-matrix/construct-view-model.ts
@@ -100,5 +100,20 @@ export const constructTrainingMatrix = (
     result.push(currentArea.value);
   }
 
-  return result;
+  for (const ownerOfArea of member.ownerOf) {
+    if (result.some(area => area.area.id === ownerOfArea.id)) {
+      continue;
+    }
+
+    result.push({
+      area: {
+        id: ownerOfArea.id as TrainingMatrix[0]['area']['id'],
+        name: ownerOfArea.name,
+        is_owner: O.some(ownerOfArea.ownershipRecordedAt),
+      },
+      equipment: [],
+    });
+  }
+
+  return result.toSorted((a, b) => a.area.name.localeCompare(b.area.name, ['en-US']));
 }

--- a/src/queries/training-matrix/render.ts
+++ b/src/queries/training-matrix/render.ts
@@ -1,6 +1,6 @@
 import * as O from 'fp-ts/Option';
 import { EquipmentId } from '../../types/equipment-id';
-import { html, HtmlSubstitution, joinHtml, Safe, sanitizeString } from '../../types/html';
+import { html, HtmlSubstitution, joinHtml, Safe, safe, sanitizeString } from '../../types/html';
 import { tooltipWith} from '../shared-render/tool-tip';
 import { FullQuizResultsForMember } from '../../read-models/external-state/equipment-quiz';
 import { UUID } from 'io-ts-types';
@@ -21,24 +21,48 @@ const renderEquipmentQuizStatus = (equipment_quiz: TrainingMatrix[0]['equipment'
   return PLACEHOLDER;
 };
 
-const renderTrainingMatrixRow = (areaColumn: HtmlSubstitution, ownerColumn: HtmlSubstitution, row: TrainingMatrix[0]['equipment'][0]) => html`
+type TrainingMatrixEquipment = TrainingMatrix[0]['equipment'][0];
+
+type TrainingMatrixRow =
+  | {
+      type: 'equipment';
+      equipment: TrainingMatrixEquipment;
+    }
+  | {
+      type: 'no-equipment';
+    };
+
+const renderEquipmentCells = (row: TrainingMatrixEquipment) => html`
+  <th scope="row">
+    <a href="/equipment/${row.equipment_id}">
+      ${sanitizeString(row.equipment_name)}
+    </a>
+  </th>
+  <th scope="row">
+    ${renderEquipmentQuizStatus(row.equipment_quiz)}
+  </th>
+  <th scope="row">
+    ${renderYes(row.is_trained)}
+  </th>
+  <th scope="row">
+    ${renderYes(row.is_trainer)}
+  </th>
+`;
+
+const renderNoEquipmentCells = html`
+  <th scope="row">No equipment assigned</th>
+  <th scope="row">${PLACEHOLDER}</th>
+  <th scope="row">${PLACEHOLDER}</th>
+  <th scope="row">${PLACEHOLDER}</th>
+`;
+
+const renderTrainingMatrixRow = (areaColumn: HtmlSubstitution, ownerColumn: HtmlSubstitution, row: TrainingMatrixRow) => html`
   <tr>
     ${areaColumn}
     ${ownerColumn}
-    <th scope="row">
-      <a href="/equipment/${row.equipment_id}">
-        ${sanitizeString(row.equipment_name)}
-      </a>
-    </th>
-    <th scope="row">
-      ${renderEquipmentQuizStatus(row.equipment_quiz)}
-    </th>
-    <th scope="row">
-      ${renderYes(row.is_trained)}
-    </th>
-    <th scope="row">
-      ${renderYes(row.is_trainer)}
-    </th>
+    ${row.type === 'equipment'
+      ? renderEquipmentCells(row.equipment)
+      : renderNoEquipmentCells}
   </tr>
 `;
 
@@ -58,13 +82,30 @@ export type TrainingMatrix = ReadonlyArray<{
 }>;
 
 export const renderTrainingMatrix = (tm: TrainingMatrix) => {
-  const flattenedWithAreaColumn: [HtmlSubstitution, HtmlSubstitution, TrainingMatrix[0]['equipment'][0]][] = [];
+  const flattenedWithAreaColumn: [HtmlSubstitution, HtmlSubstitution, TrainingMatrixRow][] = [];
   for (const area of tm) {
-    const areaColumnValue = html`<th rowspan="${area.equipment.length}">${sanitizeString(area.area.name)}</th>`;
-    const ownerColumnValue = html`<th rowspan="${area.equipment.length}">${renderYes(area.area.is_owner)}</th>`;
-    flattenedWithAreaColumn.push([areaColumnValue, ownerColumnValue, area.equipment[0]]);
+    const rowSpan = Math.max(area.equipment.length, 1);
+    const areaColumnValue = html`<th rowspan="${rowSpan}"><a href="/areas#area-${safe(area.area.id)}">${sanitizeString(area.area.name)}</a></th>`;
+    const ownerColumnValue = html`<th rowspan="${rowSpan}">${renderYes(area.area.is_owner)}</th>`;
+
+    if (area.equipment.length === 0) {
+      flattenedWithAreaColumn.push([
+        areaColumnValue,
+        ownerColumnValue,
+        {type: 'no-equipment'},
+      ]);
+      continue;
+    }
+
+    flattenedWithAreaColumn.push([areaColumnValue, ownerColumnValue, {
+      type: 'equipment',
+      equipment: area.equipment[0],
+    }]);
     for (const equipment of area.equipment.slice(1)) {
-      flattenedWithAreaColumn.push([html``, html``, equipment]);
+      flattenedWithAreaColumn.push([html``, html``, {
+        type: 'equipment',
+        equipment,
+      }]);
     }
   }
   return html`

--- a/tests/queries/areas/construct-view-model.test.ts
+++ b/tests/queries/areas/construct-view-model.test.ts
@@ -2,7 +2,6 @@ import {pipe} from 'fp-ts/lib/function';
 import {arbitraryUser} from '../../types/user.helper';
 import {getRightOrFail} from '../../helpers';
 import * as T from 'fp-ts/Task';
-import * as E from 'fp-ts/Either';
 import {constructViewModel} from '../../../src/queries/areas/construct-view-model';
 import {
   initTestFramework,
@@ -46,21 +45,29 @@ describe('construct-view-model', () => {
       T.map(getRightOrFail)
     )();
     expect(result.areas).toBeDefined();
+    expect(result.canManageAreas).toStrictEqual(true);
+    expect(result.canSeeOwnerPrivateDetails).toStrictEqual(true);
   });
 
-  it('fails if the logged in user is not a super user', async () => {
+  it('succeeds if the logged in user is not a super user', async () => {
     const result = await pipe(
       unprivilegedUser,
-      constructViewModel(framework.sharedReadModel, framework.extDB)
+      constructViewModel(framework.sharedReadModel, framework.extDB),
+      T.map(getRightOrFail)
     )();
-    expect(result).toStrictEqual(E.left(expect.anything()));
+    expect(result.areas).toBeDefined();
+    expect(result.canManageAreas).toStrictEqual(false);
+    expect(result.canSeeOwnerPrivateDetails).toStrictEqual(false);
   });
 
-  it("fails if the logged in user isn't known to the shared state", async () => {
+  it("succeeds without management permissions if the logged in user isn't known to the shared state", async () => {
     const result = await pipe(
       unregisteredUser,
-      constructViewModel(framework.sharedReadModel, framework.extDB)
+      constructViewModel(framework.sharedReadModel, framework.extDB),
+      T.map(getRightOrFail)
     )();
-    expect(result).toStrictEqual(E.left(expect.anything()));
+    expect(result.areas).toBeDefined();
+    expect(result.canManageAreas).toStrictEqual(false);
+    expect(result.canSeeOwnerPrivateDetails).toStrictEqual(false);
   });
 });

--- a/tests/queries/areas/construct-view-model.test.ts
+++ b/tests/queries/areas/construct-view-model.test.ts
@@ -1,6 +1,6 @@
 import {pipe} from 'fp-ts/lib/function';
 import {arbitraryUser} from '../../types/user.helper';
-import {getRightOrFail} from '../../helpers';
+import {getLeftOrFail, getRightOrFail} from '../../helpers';
 import * as T from 'fp-ts/Task';
 import {constructViewModel} from '../../../src/queries/areas/construct-view-model';
 import {
@@ -60,14 +60,12 @@ describe('construct-view-model', () => {
     expect(result.canSeeOwnerPrivateDetails).toStrictEqual(false);
   });
 
-  it("succeeds without management permissions if the logged in user isn't known to the shared state", async () => {
+  it("fails if the logged in user isn't known to the shared state", async () => {
     const result = await pipe(
       unregisteredUser,
       constructViewModel(framework.sharedReadModel, framework.extDB),
-      T.map(getRightOrFail)
+      T.map(getLeftOrFail)
     )();
-    expect(result.areas).toBeDefined();
-    expect(result.canManageAreas).toStrictEqual(false);
-    expect(result.canSeeOwnerPrivateDetails).toStrictEqual(false);
+    expect(result.status).toStrictEqual(401);
   });
 });

--- a/tests/queries/areas/render.test.ts
+++ b/tests/queries/areas/render.test.ts
@@ -118,7 +118,7 @@ describe('areas render', () => {
     expect(page.textContent).toContain('No equipment currently assigned to this area.');
   });
 
-  it('shows a public get-involved message when there are no active owners', () => {
+  it('shows inactive owners to normal members as public owner details', () => {
     const page = renderPage({
       areas: [
         {
@@ -130,11 +130,31 @@ describe('areas render', () => {
       canSeeOwnerPrivateDetails: false,
     });
 
-    expect(normalizedText(page)).toContain(
+    expect(page.textContent).toContain('Area Owner');
+    expect(page.textContent).toContain('123');
+    expect(page.textContent).not.toContain(ownerEmail);
+    expect(normalizedText(page)).not.toContain(
       "This area doesn't have any owners currently - email owners@makespace.org to get involved!"
     );
     expect(page.textContent).not.toContain(
       'No active owners — see inactive owners below.'
+    );
+  });
+
+  it("shows a public get-involved message when an area doesn't have any owners", () => {
+    const page = renderPage({
+      areas: [
+        {
+          ...area,
+          owners: [],
+        },
+      ],
+      canManageAreas: false,
+      canSeeOwnerPrivateDetails: false,
+    });
+
+    expect(normalizedText(page)).toContain(
+      "This area doesn't have any owners currently - email owners@makespace.org to get involved!"
     );
   });
 

--- a/tests/queries/areas/render.test.ts
+++ b/tests/queries/areas/render.test.ts
@@ -1,0 +1,117 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import * as O from 'fp-ts/Option';
+import {UUID} from 'io-ts-types';
+import {render} from '../../../src/queries/areas/render';
+import {ViewModel} from '../../../src/queries/areas/view-model';
+import {Equipment} from '../../../src/read-models/shared-state/return-types';
+import {EmailAddress, UserId} from '../../../src/types';
+
+const areaId = '11111111-1111-4111-8111-111111111111' as UUID;
+const equipmentId = '22222222-2222-4222-8222-222222222222' as UUID;
+const ownerEmail = 'owner@example.com' as EmailAddress;
+const signedAt = new Date('2025-01-02T12:00:00.000Z');
+
+const equipment = {
+  id: equipmentId,
+  name: 'Laser Cutter',
+  trainingSheetId: O.none,
+  trainers: [],
+  trainedMembers: [],
+  area: {
+    id: areaId,
+    name: 'Laser Area',
+    email: O.none,
+  },
+} satisfies Equipment;
+
+const area = {
+  id: areaId,
+  name: 'Laser Area',
+  email: O.some('laser@example.com' as EmailAddress),
+  equipment: [equipment],
+  owners: [
+    {
+      userId: '33333333-3333-4333-8333-333333333333' as UserId,
+      memberNumber: 123,
+      pastMemberNumbers: [],
+      primaryEmailAddress: ownerEmail,
+      name: O.some('Area Owner'),
+      agreementSigned: O.some(signedAt),
+      ownershipRecordedAt: new Date('2024-01-01T00:00:00.000Z'),
+      markedOwnerBy: O.none,
+      isActiveOwner: true,
+      reasons: [],
+    },
+  ],
+} satisfies ViewModel['areas'][number];
+
+const renderPage = (viewModel: ViewModel): HTMLBodyElement => {
+  const body = document.createElement('body');
+  body.innerHTML = render(viewModel);
+  return body;
+};
+
+describe('areas render', () => {
+  it('shows normal members equipment and only public owner details', () => {
+    const page = renderPage({
+      areas: [area],
+      canManageAreas: false,
+      canSeeOwnerPrivateDetails: false,
+    });
+
+    expect(page.textContent).toContain('Areas');
+    expect(page.querySelector(`#area-${areaId}`)).not.toBeNull();
+    expect(page.querySelector(`a[href="/equipment/${equipmentId}"]`)!.textContent).toContain('Laser Cutter');
+    expect(page.textContent).toContain('Area Owner');
+    expect(page.textContent).toContain('123');
+    expect(page.textContent).not.toContain(ownerEmail);
+    expect(page.textContent).not.toContain('Agreement Signed');
+    expect(page.textContent).not.toContain('Add owner');
+    expect(page.textContent).not.toContain('Add RED equipment');
+    expect(page.textContent).not.toContain('Set mailing list');
+    expect(page.textContent).not.toContain('Remove area');
+  });
+
+  it('shows owners private owner details without management actions', () => {
+    const page = renderPage({
+      areas: [area],
+      canManageAreas: false,
+      canSeeOwnerPrivateDetails: true,
+    });
+
+    expect(page.textContent).toContain(ownerEmail);
+    expect(page.textContent).toContain('Agreement Signed');
+    expect(page.textContent).toContain('02/01/2025');
+    expect(page.textContent).not.toContain('Ask to sign');
+    expect(page.textContent).not.toContain('Add owner');
+    expect(page.textContent).not.toContain('Remove area');
+  });
+
+  it('shows super users management actions', () => {
+    const page = renderPage({
+      areas: [area],
+      canManageAreas: true,
+      canSeeOwnerPrivateDetails: true,
+    });
+
+    expect(page.textContent).toContain('Add area of responsibility');
+    expect(page.textContent).toContain('Add owner');
+    expect(page.textContent).toContain('Add RED equipment');
+    expect(page.textContent).toContain('Set mailing list');
+    expect(page.textContent).toContain('Remove area');
+    expect(page.querySelector(`a[href="/areas/remove-owner?memberNumber=123&areaId=${areaId}"]`)).not.toBeNull();
+  });
+
+  it('shows a clear empty equipment message', () => {
+    const page = renderPage({
+      areas: [{...area, equipment: []}],
+      canManageAreas: false,
+      canSeeOwnerPrivateDetails: false,
+    });
+
+    expect(page.textContent).toContain('No equipment currently assigned to this area.');
+  });
+});

--- a/tests/queries/areas/render.test.ts
+++ b/tests/queries/areas/render.test.ts
@@ -54,6 +54,9 @@ const renderPage = (viewModel: ViewModel): HTMLBodyElement => {
   return body;
 };
 
+const normalizedText = (page: HTMLElement): string =>
+  page.textContent?.replace(/\s+/g, ' ').trim() ?? '';
+
 describe('areas render', () => {
   it('shows normal members equipment and only public owner details', () => {
     const page = renderPage({
@@ -113,5 +116,42 @@ describe('areas render', () => {
     });
 
     expect(page.textContent).toContain('No equipment currently assigned to this area.');
+  });
+
+  it('shows a public get-involved message when there are no active owners', () => {
+    const page = renderPage({
+      areas: [
+        {
+          ...area,
+          owners: [{...area.owners[0], isActiveOwner: false}],
+        },
+      ],
+      canManageAreas: false,
+      canSeeOwnerPrivateDetails: false,
+    });
+
+    expect(normalizedText(page)).toContain(
+      "This area doesn't have any owners currently - email owners@makespace.org to get involved!"
+    );
+    expect(page.textContent).not.toContain(
+      'No active owners — see inactive owners below.'
+    );
+  });
+
+  it('keeps the inactive-owner hint for super users', () => {
+    const page = renderPage({
+      areas: [
+        {
+          ...area,
+          owners: [{...area.owners[0], isActiveOwner: false}],
+        },
+      ],
+      canManageAreas: true,
+      canSeeOwnerPrivateDetails: true,
+    });
+
+    expect(page.textContent).toContain(
+      'No active owners — see inactive owners below.'
+    );
   });
 });

--- a/tests/queries/areas/render.test.ts
+++ b/tests/queries/areas/render.test.ts
@@ -158,6 +158,23 @@ describe('areas render', () => {
     );
   });
 
+  it("shows the public get-involved message to non-super users who can see owner private details", () => {
+    const page = renderPage({
+      areas: [
+        {
+          ...area,
+          owners: [],
+        },
+      ],
+      canManageAreas: false,
+      canSeeOwnerPrivateDetails: true,
+    });
+
+    expect(normalizedText(page)).toContain(
+      "This area doesn't have any owners currently - email owners@makespace.org to get involved!"
+    );
+  });
+
   it('keeps the inactive-owner hint for super users', () => {
     const page = renderPage({
       areas: [

--- a/tests/queries/equipment/render.test.ts
+++ b/tests/queries/equipment/render.test.ts
@@ -120,6 +120,14 @@ describe('Render equipment page', () => {
         it('cannot see revoke training button', () => {
             expect(findRevokeTrainingButton(renderedDom)).toStrictEqual(O.none);
         });
+
+        it('links to the equipment area', () => {
+            expect(
+                renderedDom.querySelector(
+                    `a[href="/areas#area-${equipment.area.id}"]`
+                )!.textContent
+            ).toContain(equipment.area.name);
+        });
     });
 
     describe('super user view', () => {

--- a/tests/queries/training-matrix/construct-training-matrix.test.ts
+++ b/tests/queries/training-matrix/construct-training-matrix.test.ts
@@ -268,6 +268,30 @@ describe('construct-training-matrix', () => {
       });
     });
 
+    describe('user is marked as an owner for an area without equipment', () => {
+      const emptyArea: CreateArea = {
+        id: faker.string.uuid() as UUID,
+        name: 'Empty Area' as NonEmptyString,
+      };
+      let trainingMatrix: TrainingMatrix;
+
+      beforeEach(async () => {
+        await framework.commands.area.create(emptyArea);
+        await framework.commands.area.addOwner({
+          areaId: emptyArea.id,
+          memberNumber: user.memberNumber,
+        });
+        trainingMatrix = await getTrainingMatrix(user.memberNumber);
+      });
+
+      it('shows the area with no equipment', () => {
+        expect(trainingMatrix).toHaveLength(1);
+        expect(trainingMatrix[0].area.id).toStrictEqual(emptyArea.id);
+        expect(trainingMatrix[0].area.name).toStrictEqual(emptyArea.name);
+        expect(trainingMatrix[0].equipment).toHaveLength(0);
+      });
+    });
+
     describe('user is marked as trained without doing quiz', () => {
       // In future we can flag cases like this
       const trainedOnMetalMill: MarkMemberTrainedBy = {

--- a/tests/queries/training-matrix/render.test.ts
+++ b/tests/queries/training-matrix/render.test.ts
@@ -1,0 +1,61 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import * as O from 'fp-ts/Option';
+import {UUID} from 'io-ts-types';
+import {renderTrainingMatrix, TrainingMatrix} from '../../../src/queries/training-matrix/render';
+import {EquipmentId} from '../../../src/types/equipment-id';
+
+const areaId = '11111111-1111-4111-8111-111111111111' as UUID;
+const equipmentId = '22222222-2222-4222-8222-222222222222' as EquipmentId;
+
+const renderPage = (trainingMatrix: TrainingMatrix): HTMLBodyElement => {
+  const body = document.createElement('body');
+  body.innerHTML = renderTrainingMatrix(trainingMatrix);
+  return body;
+};
+
+describe('training matrix render', () => {
+  it('links area names to the area page', () => {
+    const page = renderPage([
+      {
+        area: {
+          id: areaId,
+          name: 'Laser Area',
+          is_owner: O.none,
+        },
+        equipment: [
+          {
+            equipment_id: equipmentId,
+            equipment_name: 'Laser Cutter',
+            is_trainer: O.none,
+            is_trained: O.none,
+            equipment_quiz: {
+              passedAt: [],
+              attempted: [],
+            },
+          },
+        ],
+      },
+    ]);
+
+    expect(page.querySelector(`a[href="/areas#area-${areaId}"]`)!.textContent).toContain('Laser Area');
+  });
+
+  it('renders areas that have no equipment', () => {
+    const page = renderPage([
+      {
+        area: {
+          id: areaId,
+          name: 'Laser Area',
+          is_owner: O.some(new Date('2025-01-01T00:00:00.000Z')),
+        },
+        equipment: [],
+      },
+    ]);
+
+    expect(page.querySelector(`a[href="/areas#area-${areaId}"]`)!.textContent).toContain('Laser Area');
+    expect(page.textContent).toContain('No equipment assigned');
+  });
+});


### PR DESCRIPTION
https://github.com/Makespace/members-app/issues/267

### Motivation

- Replace an all-or-nothing superuser gate with per-user permissions so the Areas page can show/hide private owner details and management actions based on the logged-in member record.
- Improve UX by linking area names from equipment and training matrix pages to the corresponding area fragment and by rendering clearer messages for empty equipment lists.
- Ensure the training matrix includes areas a user owns even when those areas have no equipment.

### Description

- `construct-view-model` now reads the member from `sharedReadModel` and sets `canManageAreas` and `canSeeOwnerPrivateDetails` on the `ViewModel` instead of requiring a superuser check.
- View model type updated (`ViewModel`) to include `canManageAreas` and `canSeeOwnerPrivateDetails` flags.
- `render.ts` for Areas updated to conditionally show emails, agreement status, owner management actions, and the page-level "Add area" CTA based on the new flags; owner rows and owner lists were made permission-aware; added clearer copy for empty equipment and an `id` on area articles for fragment linking.
- `equipment/render.ts` updated to link the area name to the area page anchor `#area-<id>`.
- `training-matrix/construct-view-model.ts` now appends any areas the member owns that have no equipment and returns the areas sorted by name.
- `training-matrix/render.ts` refactored row rendering to support both equipment rows and a no-equipment row, added links for area names to the area anchor, and adjusted rowspan logic for empty equipment lists.
- Tests added and updated: updated `construct-view-model` unit tests to reflect permission flags; added `areas/render.test.ts` and `training-matrix/render.test.ts` to exercise new rendering behaviour; updated `equipment/render.test.ts` to assert the new area link and small test adjustments.

### Testing

- Ran unit tests with the project's test suite (`jest`), which exercise `construct-view-model`, `areas` rendering, `training-matrix` construction/rendering, and `equipment` rendering; all tests passed locally.
- New DOM-based rendering tests (`@jest-environment jsdom`) were added for `areas` and `training-matrix` and executed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5c98047e888332915f47b758086882)