### PR TITLE
Add ability to retire (soft-hide) equipment

### DIFF
--- a/src/commands/equipment/index.ts
+++ b/src/commands/equipment/index.ts
@@ -4,6 +4,8 @@ import {registerTrainingSheet} from './register-training-sheet';
 import {registerTrainingSheetForm} from './register-training-sheet-form';
 import {removeTrainingSheet} from './remove-training-sheet';
 import {removeTrainingSheetForm} from './remove-training-sheet-form';
+import {markEquipmentObsolete} from './mark-obsolete';
+import {markEquipmentObsoleteForm} from './mark-obsolete-form';
 
 export const equipment = {
   add: {
@@ -17,5 +19,9 @@ export const equipment = {
   removeTrainingSheet: {
     ...removeTrainingSheet,
     ...removeTrainingSheetForm,
+  },
+  markObsolete: {
+    ...markEquipmentObsolete,
+    ...markEquipmentObsoleteForm,
   },
 };

--- a/src/commands/equipment/mark-obsolete-form.ts
+++ b/src/commands/equipment/mark-obsolete-form.ts
@@ -27,7 +27,7 @@ const renderForm = (viewModel: ViewModel) =>
         </form>
       </div>
     `,
-    toLoggedInContent(safe('Retire equipment'))
+    toLoggedInContent(html`Retire equipment`)
   );
 
 const constructForm: Form<ViewModel>['constructForm'] =

--- a/src/commands/equipment/mark-obsolete-form.ts
+++ b/src/commands/equipment/mark-obsolete-form.ts
@@ -2,7 +2,7 @@ import {pipe} from 'fp-ts/lib/function';
 import * as E from 'fp-ts/Either';
 import * as TE from 'fp-ts/TaskEither';
 import {UUID} from 'io-ts-types';
-import {html, safe, sanitizeString, toLoggedInContent} from '../../types/html';
+import {html, sanitizeString, toLoggedInContent} from '../../types/html';
 import {Form} from '../../types/form';
 import {getEquipmentName} from './get-equipment-name';
 import {getEquipmentIdFromForm} from './get-equipment-id-from-form';

--- a/src/commands/equipment/mark-obsolete-form.ts
+++ b/src/commands/equipment/mark-obsolete-form.ts
@@ -6,6 +6,7 @@ import {html, safe, sanitizeString, toLoggedInContent} from '../../types/html';
 import {Form} from '../../types/form';
 import {getEquipmentName} from './get-equipment-name';
 import {getEquipmentIdFromForm} from './get-equipment-id-from-form';
+import { isAdminOrSuperUser } from '../authentication-helpers/is-admin-or-super-user';
 
 type ViewModel = {
   equipmentId: UUID;
@@ -45,5 +46,5 @@ const constructForm: Form<ViewModel>['constructForm'] =
 export const markEquipmentObsoleteForm: Form<ViewModel> = {
   renderForm,
   constructForm,
-  formIsAuthorized: null,
+  formIsAuthorized: isAdminOrSuperUser,
 };

--- a/src/commands/equipment/mark-obsolete-form.ts
+++ b/src/commands/equipment/mark-obsolete-form.ts
@@ -1,0 +1,49 @@
+import {pipe} from 'fp-ts/lib/function';
+import * as E from 'fp-ts/Either';
+import * as TE from 'fp-ts/TaskEither';
+import {UUID} from 'io-ts-types';
+import {html, safe, sanitizeString, toLoggedInContent} from '../../types/html';
+import {Form} from '../../types/form';
+import {getEquipmentName} from './get-equipment-name';
+import {getEquipmentIdFromForm} from './get-equipment-id-from-form';
+
+type ViewModel = {
+  equipmentId: UUID;
+  equipmentName: string;
+};
+
+const renderForm = (viewModel: ViewModel) =>
+  pipe(
+    html`
+      <div class="stack-large">
+        <h1>Retire '${sanitizeString(viewModel.equipmentName)}'?</h1>
+        <p>
+          It will be hidden from members looking for training. Existing training
+          records are kept.
+        </p>
+        <form action="/equipment/mark-obsolete" method="post">
+          <input type="hidden" name="id" value="${viewModel.equipmentId}" />
+          <button type="submit">Confirm and retire</button>
+        </form>
+      </div>
+    `,
+    toLoggedInContent(safe('Retire equipment'))
+  );
+
+const constructForm: Form<ViewModel>['constructForm'] =
+  input =>
+  ({readModel}) =>
+    pipe(
+      E.Do,
+      E.bind('equipmentId', () => getEquipmentIdFromForm(input)),
+      E.bind('equipmentName', ({equipmentId}) =>
+        getEquipmentName(readModel, equipmentId)
+      ),
+      TE.fromEither
+    );
+
+export const markEquipmentObsoleteForm: Form<ViewModel> = {
+  renderForm,
+  constructForm,
+  formIsAuthorized: null,
+};

--- a/src/commands/equipment/mark-obsolete.ts
+++ b/src/commands/equipment/mark-obsolete.ts
@@ -1,0 +1,39 @@
+import {constructEvent} from '../../types';
+import * as t from 'io-ts';
+import * as tt from 'io-ts-types';
+import * as O from 'fp-ts/Option';
+import * as TE from 'fp-ts/TaskEither';
+import {pipe} from 'fp-ts/lib/function';
+import {StatusCodes} from 'http-status-codes';
+import {Command} from '../command';
+import {failureWithStatus} from '../../types/failure-with-status';
+import {isAdminOrSuperUser} from '../authentication-helpers/is-admin-or-super-user';
+
+const codec = t.strict({
+  id: tt.UUID,
+});
+
+type MarkEquipmentObsolete = t.TypeOf<typeof codec>;
+
+const process: Command<MarkEquipmentObsolete>['process'] = input =>
+  pipe(
+    input.rm.equipment.get(input.command.id),
+    TE.fromOption(() =>
+      failureWithStatus(
+        'The requested equipment does not exist',
+        StatusCodes.NOT_FOUND
+      )()
+    ),
+    // Idempotent: if it is already obsolete, there is nothing to record.
+    TE.map(equipment =>
+      O.isSome(equipment.removedAt)
+        ? O.none
+        : O.some(constructEvent('EquipmentMarkedObsolete')(input.command))
+    )
+  );
+
+export const markEquipmentObsolete: Command<MarkEquipmentObsolete> = {
+  process,
+  decode: codec.decode,
+  isAuthorized: isAdminOrSuperUser,
+};

--- a/src/queries/areas/construct-view-model.ts
+++ b/src/queries/areas/construct-view-model.ts
@@ -86,7 +86,12 @@ const expandArea =
     const equipmentIds = area.equipment.map(equipment => equipment.id);
     return {
       ...area,
-      equipment: area.equipment.map(expandEquipment(now)),
+      // Hide obsolete equipment from members browsing for training. equipmentIds
+      // above still spans all equipment, so owners' training-delivered counts
+      // keep including trainings on now-retired machines.
+      equipment: area.equipment
+        .filter(equipment => O.isNone(equipment.removedAt))
+        .map(expandEquipment(now)),
       owners: await Promise.all(
         area.owners.map(expandOwner(sharedReadModel, extDB, now, equipmentIds))
       ),

--- a/src/queries/equipment/render.ts
+++ b/src/queries/equipment/render.ts
@@ -154,9 +154,7 @@ const retireEquipment = (viewModel: ViewModel) =>
             >[Admin] Retire equipment</a
           >
           ${tooltip(
-            safe(
-              'Hide this equipment from members looking for training. Training records are kept.'
-            )
+            html`Hide this equipment from members looking for training. Training records are kept.`
           )}
         </li>`
     ),

--- a/src/queries/equipment/render.ts
+++ b/src/queries/equipment/render.ts
@@ -139,11 +139,36 @@ const removeTrainingSheet = (viewModel: ViewModel) =>
     O.getOrElse(() => html``)
   );
 
+const retireEquipment = (viewModel: ViewModel) =>
+  pipe(
+    viewModel,
+    O.of,
+    O.filter(viewModel => viewModel.isSuperUser),
+    // Already-retired equipment has nothing to retire.
+    O.filter(viewModel => O.isNone(viewModel.equipment.removedAt)),
+    O.map(viewModel => viewModel.equipment.id),
+    O.map(
+      id =>
+        html` <li>
+          <a href="/equipment/mark-obsolete?equipmentId=${id}"
+            >[Admin] Retire equipment</a
+          >
+          ${tooltip(
+            safe(
+              'Hide this equipment from members looking for training. Training records are kept.'
+            )
+          )}
+        </li>`
+    ),
+    O.getOrElse(() => html``)
+  );
+
 const equipmentActions = (viewModel: ViewModel) => html`
   <ul>
     ${trainMember(viewModel)} ${adminMarkTrainedBy(viewModel)}
     ${addTrainer(viewModel)} ${registerSheet(viewModel)}
     ${currentSheet(viewModel)} ${removeTrainingSheet(viewModel)}
+    ${retireEquipment(viewModel)}
   </ul>
 `;
 

--- a/src/read-models/shared-state/equipment/get.ts
+++ b/src/read-models/shared-state/equipment/get.ts
@@ -16,6 +16,7 @@ const transformRow = <
     id: string;
     areaId: string;
     trainingSheetId: string | undefined | null;
+    removedAt: Date | undefined | null;
   },
 >(
   row: R
@@ -24,6 +25,7 @@ const transformRow = <
   id: row.id as UUID,
   areaId: row.areaId as UUID,
   trainingSheetId: O.fromNullable(row.trainingSheetId),
+  removedAt: O.fromNullable(row.removedAt),
 });
 
 export const getEquipmentForAreaMinimal =

--- a/src/read-models/shared-state/return-types.ts
+++ b/src/read-models/shared-state/return-types.ts
@@ -26,6 +26,8 @@ export type MinimalEquipment = {
   name: string;
   areaId: UUID;
   trainingSheetId: O.Option<string>;
+  // Set when the equipment has been marked obsolete (soft-hidden).
+  removedAt: O.Option<Date>;
 };
 
 export type Equipment = {

--- a/src/read-models/shared-state/state.ts
+++ b/src/read-models/shared-state/state.ts
@@ -100,6 +100,7 @@ export const equipmentTable = defineTable(
       name TEXT,
       areaId TEXT,
       trainingSheetId TEXT,
+      removedAt INTEGER,
       FOREIGN KEY(areaId) REFERENCES areas(id) ON DELETE CASCADE
     );
   `,
@@ -111,6 +112,9 @@ export const equipmentTable = defineTable(
       .notNull()
       .references(() => areasTable.id, { onDelete: 'cascade' }),
     trainingSheetId: text('trainingSheetId'),
+    // When set, the equipment is obsolete: hidden from members browsing for
+    // training, but kept (with its history) for owners/admins.
+    removedAt: integer('removedAt', {mode: 'timestamp_ms'}),
   }
 );
 

--- a/src/read-models/shared-state/update-state.ts
+++ b/src/read-models/shared-state/update-state.ts
@@ -223,6 +223,21 @@ const _updateState =
           .run();
         break;
       }
+      case 'EquipmentMarkedObsolete': {
+        // Soft-hide only: flag the row, keep its trainers/trained-members so no
+        // training history is lost.
+        const rows = tx
+          .update(equipmentTable)
+          .set({removedAt: event.recordedAt})
+          .where(eq(equipmentTable.id, event.id))
+          .run();
+        if (rows.changes === 0) {
+          throw new InconsistentEventError(
+            `Unable to mark equipment obsolete for ${event.id} - unknown equipment`
+          );
+        }
+        break;
+      }
       case 'TrainerAdded': {
         const userId = findUserIdByMemberNumber(tx)(event.memberNumber);
         if (O.isNone(userId)) {

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -49,6 +49,11 @@ export const initRoutes = (
     ),
     ...command(
       'equipment',
+      'mark-obsolete',
+      commands.equipment.markObsolete
+    ),
+    ...command(
+      'equipment',
       'mark-member-trained',
       commands.trainers.markTrained
     ),

--- a/src/types/domain-event.ts
+++ b/src/types/domain-event.ts
@@ -52,6 +52,12 @@ const EquipmentAdded = defineEvent('EquipmentAdded', {
   areaId: tt.UUID,
 });
 
+// Soft-hide: the equipment and its training history stay in the log/read model,
+// but it is treated as obsolete (hidden from members browsing for training).
+const EquipmentMarkedObsolete = defineEvent('EquipmentMarkedObsolete', {
+  id: tt.UUID,
+});
+
 const OwnerAdded = defineEvent('OwnerAdded', {
   areaId: tt.UUID,
   memberNumber: t.number,
@@ -219,6 +225,7 @@ export const events = [
   AreaRemoved,
   AreaEmailUpdated,
   EquipmentAdded,
+  EquipmentMarkedObsolete,
   OwnerAdded,
   OwnerRemoved,
   SuperUserDeclared,
@@ -252,6 +259,7 @@ export const DomainEvent = t.union([
   AreaRemoved.codec,
   AreaEmailUpdated.codec,
   EquipmentAdded.codec,
+  EquipmentMarkedObsolete.codec,
   OwnerAdded.codec,
   OwnerRemoved.codec,
   SuperUserDeclared.codec,

--- a/tests/commands/equipment/mark-obsolete.test.ts
+++ b/tests/commands/equipment/mark-obsolete.test.ts
@@ -1,0 +1,109 @@
+import * as O from 'fp-ts/Option';
+import {faker} from '@faker-js/faker';
+import {StatusCodes} from 'http-status-codes';
+import {NonEmptyString, UUID} from 'io-ts-types';
+import {v4} from 'uuid';
+import {constructEvent} from '../../../src/types';
+import {markEquipmentObsolete} from '../../../src/commands/equipment/mark-obsolete';
+import {
+  arbitraryActor,
+  getLeftOrFail,
+  getTaskEitherRightOrFail,
+} from '../../helpers';
+import {
+  TestFramework,
+  initTestFramework,
+} from '../../read-models/test-framework';
+
+describe('mark-obsolete', () => {
+  let framework: TestFramework;
+
+  beforeEach(async () => {
+    framework = await initTestFramework();
+  });
+
+  afterEach(() => {
+    framework.close();
+  });
+
+  const areaId = v4() as UUID;
+  const equipmentId = v4() as UUID;
+  const command = {id: equipmentId, actor: arbitraryActor()};
+
+  const seedEquipment = () => {
+    framework.insertIntoSharedReadModel(
+      constructEvent('AreaCreated')({
+        id: areaId,
+        name: faker.commerce.productName() as NonEmptyString,
+        actor: arbitraryActor(),
+      })
+    );
+    framework.insertIntoSharedReadModel(
+      constructEvent('EquipmentAdded')({
+        id: equipmentId,
+        name: faker.commerce.productName(),
+        areaId,
+        actor: arbitraryActor(),
+      })
+    );
+  };
+
+  describe('when the equipment does not exist', () => {
+    it('fails with not found', async () => {
+      const result = getLeftOrFail(
+        await markEquipmentObsolete.process({
+          command,
+          rm: framework.sharedReadModel,
+        })()
+      );
+
+      expect(result).toMatchObject({
+        message: 'The requested equipment does not exist',
+        status: StatusCodes.NOT_FOUND,
+      });
+    });
+  });
+
+  describe('when the equipment exists', () => {
+    it('records an EquipmentMarkedObsolete event', async () => {
+      seedEquipment();
+
+      const result = await getTaskEitherRightOrFail(
+        markEquipmentObsolete.process({
+          command,
+          rm: framework.sharedReadModel,
+        })
+      );
+
+      expect(result).toStrictEqual(
+        O.some(
+          expect.objectContaining({
+            type: 'EquipmentMarkedObsolete',
+            id: equipmentId,
+          })
+        )
+      );
+    });
+  });
+
+  describe('when the equipment is already obsolete', () => {
+    it('is a no-op (idempotent), without failing', async () => {
+      seedEquipment();
+      framework.insertIntoSharedReadModel(
+        constructEvent('EquipmentMarkedObsolete')({
+          id: equipmentId,
+          actor: arbitraryActor(),
+        })
+      );
+
+      const result = await getTaskEitherRightOrFail(
+        markEquipmentObsolete.process({
+          command,
+          rm: framework.sharedReadModel,
+        })
+      );
+
+      expect(result).toStrictEqual(O.none);
+    });
+  });
+});

--- a/tests/commands/equipment/mark-obsolete.test.ts
+++ b/tests/commands/equipment/mark-obsolete.test.ts
@@ -1,4 +1,5 @@
 import * as O from 'fp-ts/Option';
+import * as E from 'fp-ts/Either';
 import {faker} from '@faker-js/faker';
 import {StatusCodes} from 'http-status-codes';
 import {NonEmptyString, UUID} from 'io-ts-types';
@@ -8,6 +9,7 @@ import {markEquipmentObsolete} from '../../../src/commands/equipment/mark-obsole
 import {
   arbitraryActor,
   getLeftOrFail,
+  getRightOrFail,
   getTaskEitherRightOrFail,
 } from '../../helpers';
 import {
@@ -26,33 +28,11 @@ describe('mark-obsolete', () => {
     framework.close();
   });
 
-  const areaId = v4() as UUID;
-  const equipmentId = v4() as UUID;
-  const command = {id: equipmentId, actor: arbitraryActor()};
-
-  const seedEquipment = () => {
-    framework.insertIntoSharedReadModel(
-      constructEvent('AreaCreated')({
-        id: areaId,
-        name: faker.commerce.productName() as NonEmptyString,
-        actor: arbitraryActor(),
-      })
-    );
-    framework.insertIntoSharedReadModel(
-      constructEvent('EquipmentAdded')({
-        id: equipmentId,
-        name: faker.commerce.productName(),
-        areaId,
-        actor: arbitraryActor(),
-      })
-    );
-  };
-
   describe('when the equipment does not exist', () => {
     it('fails with not found', async () => {
       const result = getLeftOrFail(
         await markEquipmentObsolete.process({
-          command,
+          command: {id: v4() as UUID, actor: arbitraryActor()},
           rm: framework.sharedReadModel,
         })()
       );
@@ -65,9 +45,27 @@ describe('mark-obsolete', () => {
   });
 
   describe('when the equipment exists', () => {
+    const areaId = v4() as UUID;
+    const equipmentId = v4() as UUID;
+    const command = {id: equipmentId, actor: arbitraryActor()};
+    beforeEach(() => {
+      framework.insertIntoSharedReadModel(
+        constructEvent('AreaCreated')({
+          id: areaId,
+          name: faker.commerce.productName() as NonEmptyString,
+          actor: arbitraryActor(),
+        })
+      );
+      framework.insertIntoSharedReadModel(
+        constructEvent('EquipmentAdded')({
+          id: equipmentId,
+          name: faker.commerce.productName(),
+          areaId,
+          actor: arbitraryActor(),
+        })
+      );
+    });
     it('records an EquipmentMarkedObsolete event', async () => {
-      seedEquipment();
-
       const result = await getTaskEitherRightOrFail(
         markEquipmentObsolete.process({
           command,
@@ -84,26 +82,29 @@ describe('mark-obsolete', () => {
         )
       );
     });
-  });
 
-  describe('when the equipment is already obsolete', () => {
-    it('is a no-op (idempotent), without failing', async () => {
-      seedEquipment();
-      framework.insertIntoSharedReadModel(
-        constructEvent('EquipmentMarkedObsolete')({
-          id: equipmentId,
-          actor: arbitraryActor(),
-        })
-      );
-
-      const result = await getTaskEitherRightOrFail(
-        markEquipmentObsolete.process({
-          command,
-          rm: framework.sharedReadModel,
-        })
-      );
-
-      expect(result).toStrictEqual(O.none);
+    describe('when the equipment is already obsolete', () => {
+      beforeEach(() => {
+        framework.insertIntoSharedReadModel(
+          constructEvent('EquipmentMarkedObsolete')({
+            id: equipmentId,
+            actor: arbitraryActor(),
+          })
+        );
+      });
+      describe('mark equipment as obsolete', () => {
+        let result: E.Either<unknown, unknown>;
+        beforeEach(async () => {
+          result = await markEquipmentObsolete.process({
+            command,
+            rm: framework.sharedReadModel,
+          })();
+        });
+        
+        it('is a no-op (idempotent), without failing', async () => {
+          expect(getRightOrFail(result)).toStrictEqual(O.none);
+        });
+      });
     });
   });
 });

--- a/tests/queries/areas/render.test.ts
+++ b/tests/queries/areas/render.test.ts
@@ -22,6 +22,7 @@ const equipment = {
   id: equipmentId,
   name: 'Laser Cutter',
   trainingSheetId: O.none,
+  removedAt: O.none,
   trainers: [],
   trainedMembers: [],
   area: {

--- a/tests/queries/equipment/render.test.ts
+++ b/tests/queries/equipment/render.test.ts
@@ -70,6 +70,7 @@ describe('Render equipment page', () => {
             trainedMember
         ],
         trainingSheetId: O.some(faker.string.alpha({length: 20})),
+        removedAt: O.none,
         area: {
             id: faker.string.uuid() as UUID,
             name: faker.airline.airline().name,

--- a/tests/read-models/shared-state/mark-equipment-obsolete.test.ts
+++ b/tests/read-models/shared-state/mark-equipment-obsolete.test.ts
@@ -1,0 +1,77 @@
+import {faker} from '@faker-js/faker';
+import {NonEmptyString, UUID} from 'io-ts-types';
+import {Int} from 'io-ts';
+import * as O from 'fp-ts/Option';
+import {EmailAddress} from '../../../src/types';
+import {getSomeOrFail} from '../../helpers';
+import {TestFramework, initTestFramework} from '../test-framework';
+
+describe('mark equipment obsolete (read model)', () => {
+  let framework: TestFramework;
+  const equipmentId = faker.string.uuid() as UUID;
+  const areaId = faker.string.uuid() as UUID;
+  const trainer = {
+    memberNumber: faker.number.int(),
+    email: faker.internet.email() as EmailAddress,
+    name: undefined,
+    formOfAddress: undefined,
+  };
+  const trained = {
+    memberNumber: faker.number.int() as Int,
+    email: faker.internet.email() as EmailAddress,
+    name: undefined,
+    formOfAddress: undefined,
+  };
+
+  const getEquipment = () =>
+    getSomeOrFail(framework.sharedReadModel.equipment.get(equipmentId));
+
+  beforeEach(async () => {
+    framework = await initTestFramework();
+    await framework.commands.memberNumbers.linkNumberToEmail(trainer);
+    await framework.commands.memberNumbers.linkNumberToEmail(trained);
+    await framework.commands.area.create({
+      id: areaId,
+      name: faker.airline.airport().name as NonEmptyString,
+    });
+    await framework.commands.equipment.add({
+      id: equipmentId,
+      name: faker.science.chemicalElement().name as NonEmptyString,
+      areaId,
+    });
+    await framework.commands.area.addOwner({
+      memberNumber: trainer.memberNumber,
+      areaId,
+    });
+    await framework.commands.trainers.add({
+      memberNumber: trainer.memberNumber,
+      equipmentId,
+    });
+    await framework.commands.trainers.markTrained({
+      equipmentId,
+      memberNumber: trained.memberNumber,
+    });
+  });
+
+  afterEach(() => framework.close());
+
+  it('is not obsolete before the event', () => {
+    expect(getEquipment().removedAt).toStrictEqual(O.none);
+  });
+
+  describe('after marking it obsolete', () => {
+    beforeEach(async () => {
+      await framework.commands.equipment.markObsolete({id: equipmentId});
+    });
+
+    it('sets removedAt', () => {
+      expect(O.isSome(getEquipment().removedAt)).toBe(true);
+    });
+
+    it('keeps the trainer and trained-member records', () => {
+      const equipment = getEquipment();
+      expect(equipment.trainers).toHaveLength(1);
+      expect(equipment.trainedMembers).toHaveLength(1);
+    });
+  });
+});

--- a/tests/read-models/test-framework.ts
+++ b/tests/read-models/test-framework.ts
@@ -175,6 +175,7 @@ export const initTestFramework = async (): Promise<TestFramework> => {
         removeTrainingSheet: frameworkify(
           commands.equipment.removeTrainingSheet
         ),
+        markObsolete: frameworkify(commands.equipment.markObsolete),
       },
       trainers: {
         add: frameworkify(commands.trainers.add),


### PR DESCRIPTION
First step of letting super-users **retire** a piece of equipment: it stops appearing to members browsing for training, but nothing is deleted — the equipment and all its training history stay in the event log and read model. This is the event-sourced "hide, don't delete" pattern (like `AreaRemoved`), but genuinely soft: a flag, not a row deletion.

## What's here
- **`EquipmentMarkedObsolete` event** + a nullable **`removedAt`** flag on the equipment read model. On the event the row is flagged (its trainers / trained-members are **kept**), so no training record is lost.
- **`markEquipmentObsolete` command** (super-user, idempotent — no-op if already obsolete) + a confirm form, reusing the shared `getEquipmentIdFromForm` / `getEquipmentName` helpers.
- **"[Admin] Retire equipment"** action on the equipment page (hidden once already retired).
- The **`/areas` browse hides obsolete equipment**, while owners' training-delivered counts still span it (`equipmentIds` keeps the full set, so trainings on retired machines still count).

## Design notes
- The flag is soft: obsolete equipment stays fully queryable, so a later PR can surface "retired" markers and still resolve historical training. Deliberately **not** the hard-delete approach (which would drop trainers/trained-members).
- Authorization is enforced on the command (`isAdminOrSuperUser`); the button is just a convenience.

## Scope / follow-ups (deliberately deferred)
This is the minimal vertical slice. Planned next:
- Reversibility (un-retire via an `EquipmentMarkedActive` event + restore action).
- A "retired" badge/banner in owner & admin views (member profile, trainings-delivered, equipment page).
- The training-matrix rule (hide obsolete a member has no training on; keep the ones they earned).

## Testing
- Command: not-found → 404, success emits `EquipmentMarkedObsolete`, already-obsolete → idempotent no-op.
- Read model: `removedAt` is set, and trainer + trained-member records are preserved.
- Full suite green (752), typecheck / lint / unused-exports clean; app boots cleanly rebuilding from real data with the new schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)