### PR TITLE
Repoint training-quiz reads from the sheet cache to events

### DIFF
--- a/src/queries/equipment/render.ts
+++ b/src/queries/equipment/render.ts
@@ -18,7 +18,7 @@ import {UUID} from 'io-ts-types';
 import {renderMembersAsList} from '../../templates/member-link-list';
 import {currentTrainingSheetButton} from '../shared-render/current-training-sheet-button';
 import {
-  EquipmentQuizResults,
+  QuizRow,
   MemberAwaitingTraining,
   OrphanedPassedQuiz,
 } from '../../read-models/external-state/equipment-quiz';
@@ -320,17 +320,17 @@ const unknownMemberWaitingForTrainingTable = (viewModel: ViewModel) =>
     O.getOrElse(() => html`<p>No training quiz data available</p>`)
   );
 
-const failedQuizRow = (row: EquipmentQuizResults['failedQuizes'][0]) => html`
+const failedQuizRow = (row: QuizRow) => html`
   <tr class="failed_training_quiz_row">
-    <td>${displayDate(DateTime.fromJSDate(row.response_submitted))}</td>
+    <td>${displayDate(DateTime.fromJSDate(row.completedAt))}</td>
     <td>
       ${pipe(
-        O.fromNullable(row.member_number_provided),
+        row.memberNumberProvided,
         O.map(renderMemberNumber),
         O.getOrElse(() => html`-`)
       )}
     </td>
-    <td>${row.score} / ${row.max_score} (${row.percentage}%)</td>
+    <td>${row.score} / ${row.maxScore} (${row.percentage}%)</td>
   </tr>
 `;
 

--- a/src/queries/member/construct-view-model.ts
+++ b/src/queries/member/construct-view-model.ts
@@ -15,7 +15,7 @@ import { getRecurlyStatusForMember } from '../../read-models/external-state/recu
 
 export const constructViewModel =
   (
-    deps: Pick<Dependencies, 'sharedReadModel' | 'getSheetDataByMemberNumber' | 'extDB'>,
+    deps: Pick<Dependencies, 'sharedReadModel' | 'extDB'>,
     user: User
   ) =>
   (memberNumber: number): TE.TaskEither<FailureWithStatus, ViewModel> => async () => {

--- a/src/read-models/external-state/equipment-quiz.ts
+++ b/src/read-models/external-state/equipment-quiz.ts
@@ -1,21 +1,14 @@
 import * as O from 'fp-ts/Option';
 import * as TE from 'fp-ts/TaskEither';
-import * as RA from 'fp-ts/ReadonlyArray';
 import * as RR from 'fp-ts/ReadonlyRecord';
 
 import {Dependencies} from '../../dependencies';
-import {SheetDataTable} from '../../sync-worker/google/sheet-data-table';
 import {pipe} from 'fp-ts/lib/function';
 import {Equipment, MemberCoreInfo} from '../shared-state/return-types';
 import {DateTime, Duration} from 'luxon';
-import { ReadonlyRecord } from 'fp-ts/lib/ReadonlyRecord';
-import { EquipmentId } from '../../types/equipment-id';
-
-export type EquipmentQuizResults = {
-  passedQuizes: SheetDataTable['rows'];
-  failedQuizes: SheetDataTable['rows'];
-  lastQuizSync: O.Option<Date>;
-};
+import {ReadonlyRecord} from 'fp-ts/lib/ReadonlyRecord';
+import {EquipmentId} from '../../types/equipment-id';
+import {TrainingQuizCompletionRow} from '../shared-state/training-quiz/get';
 
 export type OrphanedPassedQuiz = {
   waitingSince: Date;
@@ -30,99 +23,97 @@ export type MemberAwaitingTraining = Pick<
   waitingSince: Date;
 };
 
-const isPassed = (row: SheetDataTable['rows'][0]) => row.percentage >= 100;
-const isFailed = (row: SheetDataTable['rows'][0]) => !isPassed(row);
-
-const extractPassedQuizes = (
-  sheetData: SheetDataTable['rows']
-): SheetDataTable['rows'] =>
-  pipe(
-    sheetData,
-    RA.filter(isPassed)
-  );
-
-const extractFailedQuizes = (
-  sheetData: SheetDataTable['rows']
-): SheetDataTable['rows'] =>
-  pipe(
-    sheetData,
-    RA.filter(isFailed)
-  );
-
-const getQuizResults = (
-  deps: Pick<Dependencies, 'lastQuizSync' | 'getSheetData'>,
-  sheetId: string,
-  _skip: ReadonlyArray<Pick<MemberCoreInfo, 'memberNumber' | 'pastMemberNumbers'>>
-): TE.TaskEither<string, EquipmentQuizResults> => {
-  return pipe(
-    TE.Do,
-    TE.apS('lastQuizSync', deps.lastQuizSync(sheetId)),
-    TE.bind('sheetData', () =>
-      deps.getSheetData(
-        sheetId,
-        O.some(
-          DateTime.now()
-            .minus(Duration.fromObject({year: 1}))
-            .toJSDate()
-        )
-        // skip.flatMap(allMemberNumbers),
-        // skip.map(m => m.emailAddress)
-      )
-    ),
-    TE.let('passedQuizes', ({sheetData}) => extractPassedQuizes(sheetData)),
-    TE.let('failedQuizes', ({sheetData}) => extractFailedQuizes(sheetData))
-  );
+// Event-native quiz row carrying only the fields the renderers consume (the
+// events table has no sheet_name/row_index/cached_at/percentage columns).
+export type QuizRow = {
+  completedAt: Date;
+  memberNumberProvided: O.Option<number>;
+  emailProvided: O.Option<string>;
+  score: number;
+  maxScore: number;
+  percentage: number;
+  trainingSheetId: string;
 };
+
+// Full marks. The `maxScore > 0` guard avoids a spurious pass on a malformed
+// 0/0 row (the old sheet rule was a stored `percentage >= 100`).
+const isPassed = (r: {score: number; maxScore: number}) =>
+  r.maxScore > 0 && r.score >= r.maxScore;
+
+const toPercentage = (score: number, maxScore: number): number =>
+  maxScore === 0 ? 0 : Math.round((score / maxScore) * 100);
+
+const toQuizRow = (row: TrainingQuizCompletionRow): QuizRow => ({
+  completedAt: row.completedAt,
+  memberNumberProvided: row.memberNumberProvided,
+  emailProvided: row.emailProvided,
+  score: row.score,
+  maxScore: row.maxScore,
+  percentage: toPercentage(row.score, row.maxScore),
+  trainingSheetId: row.trainingSheetId,
+});
 
 export type FullQuizResultsForEquipment = {
   lastQuizSync: O.Option<Date>;
   membersAwaitingTraining: ReadonlyArray<MemberAwaitingTraining>;
   unknownMembersAwaitingTraining: ReadonlyArray<OrphanedPassedQuiz>;
-  failedQuizes: SheetDataTable['rows'];
+  failedQuizes: ReadonlyArray<QuizRow>;
 };
 
 export const getFullQuizResultsForEquipment = (
-  deps: Pick<Dependencies, 'sharedReadModel' | 'lastQuizSync' | 'getSheetData'>,
+  deps: Pick<Dependencies, 'sharedReadModel' | 'lastQuizSync'>,
   sheetId: string,
   equipment: Equipment
 ): TE.TaskEither<string, FullQuizResultsForEquipment> =>
   pipe(
-    getQuizResults(deps, sheetId, equipment.trainedMembers),
-    TE.map(qr => {
+    // The sheet cache still syncs, so lastQuizSync remains the "data last
+    // refreshed" signal shown on the page even though quiz rows now come from
+    // events.
+    deps.lastQuizSync(sheetId),
+    TE.map(lastQuizSync => {
+      const completions =
+        deps.sharedReadModel.trainingQuiz.getCompletionsForSheet(
+          sheetId,
+          O.some(
+            DateTime.now().minus(Duration.fromObject({year: 1})).toJSDate()
+          )
+        );
+
       const membersAwaitingTraining: MemberAwaitingTraining[] = [];
       const unknownMembersAwaitingTraining: OrphanedPassedQuiz[] = [];
+      const trainedMemberNumbers = equipment.trainedMembers.map(
+        m => m.memberNumber
+      );
 
-      for (const row of qr.passedQuizes) {
-        if (!row.member_number_provided) {
+      for (const row of completions.filter(isPassed)) {
+        // A passed row with no member number is dropped (not surfaced as
+        // unknown) - preserving the previous behaviour.
+        if (O.isNone(row.memberNumberProvided)) {
           continue;
         }
-        if (
-          equipment.trainedMembers
-            .map(m => m.memberNumber)
-            .includes(row.member_number_provided)
-        ) {
+        const memberNumber = row.memberNumberProvided.value;
+        if (trainedMemberNumbers.includes(memberNumber)) {
           continue;
         }
-        const member = deps.sharedReadModel.members.getByMemberNumber(
-          row.member_number_provided
-        );
+        const member =
+          deps.sharedReadModel.members.getByMemberNumber(memberNumber);
         if (O.isNone(member)) {
           unknownMembersAwaitingTraining.push({
-            waitingSince: row.response_submitted,
-            memberNumberProvided: O.fromNullable(row.member_number_provided),
-            emailProvided: O.fromNullable(row.email_provided),
+            waitingSince: row.completedAt,
+            memberNumberProvided: row.memberNumberProvided,
+            emailProvided: row.emailProvided,
           });
           continue;
         }
         membersAwaitingTraining.push({
           ...member.value,
-          waitingSince: row.response_submitted,
+          waitingSince: row.completedAt,
         });
       }
 
       return {
-        lastQuizSync: qr.lastQuizSync,
-        failedQuizes: qr.failedQuizes,
+        lastQuizSync,
+        failedQuizes: completions.filter(row => !isPassed(row)).map(toQuizRow),
         membersAwaitingTraining,
         unknownMembersAwaitingTraining,
       };
@@ -130,55 +121,63 @@ export const getFullQuizResultsForEquipment = (
   );
 
 export type FullQuizResultsForMember = {
-  equipmentQuiz: ReadonlyRecord<EquipmentId, {
-    passedAt: ReadonlyArray<Date>,
-    attempted: ReadonlyArray<{
-      response_submitted: Date,
-      sheet_id: string;
-      score: number;
-      max_score: number;
-      percentage: number;
-    }>
-  }>,
+  equipmentQuiz: ReadonlyRecord<
+    EquipmentId,
+    {
+      passedAt: ReadonlyArray<Date>;
+      attempted: ReadonlyArray<{
+        response_submitted: Date;
+        sheet_id: string;
+        score: number;
+        max_score: number;
+        percentage: number;
+      }>;
+    }
+  >;
 };
 
 export const getFullQuizResultsForMember = (
-  deps: Pick<Dependencies, 'sharedReadModel' | 'getSheetDataByMemberNumber'>,
+  deps: Pick<Dependencies, 'sharedReadModel'>,
   memberNumber: number
-): TE.TaskEither<string, FullQuizResultsForMember> => pipe(
-  deps.getSheetDataByMemberNumber(memberNumber),
-  TE.map(
-    qr => {
-      const equipmentQuiz: Record<EquipmentId, {
-        passedAt: Date[],
-        attempted: {
-            response_submitted: Date;
-            sheet_id: string;
-            score: number;
-            max_score: number;
-            percentage: number;
-        }[],
-      }> = {};
-      const trainingSheetMapping = deps.sharedReadModel.equipment.getTrainingSheetIdMapping();
-      for (const row of qr) {
-        const equipmentId = RR.lookup(row.sheet_id)(trainingSheetMapping);
-        if (O.isSome(equipmentId)) {
-          if (!equipmentQuiz[equipmentId.value]) {
-            equipmentQuiz[equipmentId.value] = {
-              passedAt: [],
-              attempted: [],
-            };
-          }
-          if (isPassed(row)) {
-            equipmentQuiz[equipmentId.value].passedAt.push(row.response_submitted);
-          } else {
-            equipmentQuiz[equipmentId.value].attempted.push(row);
-          }
-        }
-      }
-      return {
-        equipmentQuiz
-      }
+): TE.TaskEither<string, FullQuizResultsForMember> => {
+  const equipmentQuiz: Record<
+    EquipmentId,
+    {
+      passedAt: Date[];
+      attempted: {
+        response_submitted: Date;
+        sheet_id: string;
+        score: number;
+        max_score: number;
+        percentage: number;
+      }[];
     }
-  )
-);
+  > = {};
+  const trainingSheetMapping =
+    deps.sharedReadModel.equipment.getTrainingSheetIdMapping();
+
+  for (const row of deps.sharedReadModel.trainingQuiz.getCompletionsForMember(
+    memberNumber
+  )) {
+    const equipmentId = RR.lookup(row.trainingSheetId)(trainingSheetMapping);
+    if (O.isNone(equipmentId)) {
+      continue;
+    }
+    if (!equipmentQuiz[equipmentId.value]) {
+      equipmentQuiz[equipmentId.value] = {passedAt: [], attempted: []};
+    }
+    if (isPassed(row)) {
+      equipmentQuiz[equipmentId.value].passedAt.push(row.completedAt);
+    } else {
+      equipmentQuiz[equipmentId.value].attempted.push({
+        response_submitted: row.completedAt,
+        sheet_id: row.trainingSheetId,
+        score: row.score,
+        max_score: row.maxScore,
+        percentage: toPercentage(row.score, row.maxScore),
+      });
+    }
+  }
+
+  return TE.right({equipmentQuiz});
+};

--- a/src/read-models/shared-state/index.ts
+++ b/src/read-models/shared-state/index.ts
@@ -27,7 +27,13 @@ import {
 import {dumpCurrentState, SharedDatabaseDump} from './debug/dump';
 import {DateTime} from 'luxon';
 import {getLastSent} from './training-stat-notifications/get-last-sent';
-import {getImportedQuizRowHashes, hasQuizRowHash} from './training-quiz/get';
+import {
+  getCompletionsForMember,
+  getCompletionsForSheet,
+  getImportedQuizRowHashes,
+  hasQuizRowHash,
+  TrainingQuizCompletionRow,
+} from './training-quiz/get';
 import { ReadonlyRecord } from 'fp-ts/lib/ReadonlyRecord';
 import { TrainingSheetId } from '../../types/training-sheet';
 import { EquipmentId } from '../../types/equipment-id';
@@ -84,6 +90,13 @@ export type SharedReadModel = {
   trainingQuiz: {
     hasRowHash: (rowHash: string) => boolean;
     importedRowHashes: () => ReadonlySet<string>;
+    getCompletionsForSheet: (
+      trainingSheetId: string,
+      since: O.Option<Date>
+    ) => ReadonlyArray<TrainingQuizCompletionRow>;
+    getCompletionsForMember: (
+      memberNumber: number
+    ) => ReadonlyArray<TrainingQuizCompletionRow>;
   };
 };
 
@@ -143,6 +156,8 @@ export const initSharedReadModel = (
     trainingQuiz: {
       hasRowHash: hasQuizRowHash(readModelDb),
       importedRowHashes: getImportedQuizRowHashes(readModelDb),
+      getCompletionsForSheet: getCompletionsForSheet(readModelDb),
+      getCompletionsForMember: getCompletionsForMember(readModelDb),
     },
   };
 };

--- a/src/read-models/shared-state/training-quiz/get.ts
+++ b/src/read-models/shared-state/training-quiz/get.ts
@@ -1,6 +1,74 @@
 import {BetterSQLite3Database} from 'drizzle-orm/better-sqlite3';
-import {eq} from 'drizzle-orm';
+import {and, eq, gt} from 'drizzle-orm';
+import * as O from 'fp-ts/Option';
 import {trainingQuizCompletionsTable} from '../state';
+
+// One imported quiz completion, from the event-sourced read model. Raw sheet
+// facts only - member/equipment resolution happens in the consumers.
+export type TrainingQuizCompletionRow = {
+  rowHash: string;
+  trainingSheetId: string;
+  completedAt: Date;
+  memberNumberProvided: O.Option<number>;
+  emailProvided: O.Option<string>;
+  score: number;
+  maxScore: number;
+};
+
+const rowToCompletion = (row: {
+  rowHash: string;
+  trainingSheetId: string;
+  completedAt: Date;
+  memberNumberProvided: number | null;
+  emailProvided: string | null;
+  score: number;
+  maxScore: number;
+}): TrainingQuizCompletionRow => ({
+  rowHash: row.rowHash,
+  trainingSheetId: row.trainingSheetId,
+  completedAt: row.completedAt,
+  memberNumberProvided: O.fromNullable(row.memberNumberProvided),
+  emailProvided: O.fromNullable(row.emailProvided),
+  score: row.score,
+  maxScore: row.maxScore,
+});
+
+// Completions for one training sheet, optionally only those completed strictly
+// after `since` (matching the sheet cache's `gt` window). Uses the
+// trainingSheetId index.
+export const getCompletionsForSheet =
+  (db: BetterSQLite3Database) =>
+  (
+    trainingSheetId: string,
+    since: O.Option<Date>
+  ): ReadonlyArray<TrainingQuizCompletionRow> =>
+    db
+      .select()
+      .from(trainingQuizCompletionsTable)
+      .where(
+        O.isSome(since)
+          ? and(
+              eq(trainingQuizCompletionsTable.trainingSheetId, trainingSheetId),
+              gt(trainingQuizCompletionsTable.completedAt, since.value)
+            )
+          : eq(trainingQuizCompletionsTable.trainingSheetId, trainingSheetId)
+      )
+      .all()
+      .map(rowToCompletion);
+
+// All completions a member number was recorded against (whole history - no
+// window, matching the member page today). Uses the memberNumberProvided index.
+export const getCompletionsForMember =
+  (db: BetterSQLite3Database) =>
+  (memberNumber: number): ReadonlyArray<TrainingQuizCompletionRow> =>
+    db
+      .select()
+      .from(trainingQuizCompletionsTable)
+      .where(
+        eq(trainingQuizCompletionsTable.memberNumberProvided, memberNumber)
+      )
+      .all()
+      .map(rowToCompletion);
 
 // Has a quiz row with this hash already been imported as an event?
 export const hasQuizRowHash =

--- a/tests/queries/training-matrix/construct-training-matrix.test.ts
+++ b/tests/queries/training-matrix/construct-training-matrix.test.ts
@@ -14,7 +14,6 @@ import { CreateArea } from '../../../src/commands/area/create';
 import { NonEmptyString, UUID } from 'io-ts-types';
 import { AddEquipment } from '../../../src/commands/equipment/add';
 import { EquipmentId } from '../../../src/types/equipment-id';
-import { SheetDataTable } from '../../../src/sync-worker/google/sheet-data-table';
 import { RegisterTrainingSheet } from '../../../src/commands/equipment/register-training-sheet';
 import * as O from 'fp-ts/Option';
 import { Int } from 'io-ts';
@@ -344,22 +343,21 @@ describe('construct-training-matrix', () => {
     });
 
     describe('user passes the quiz for the metal mill', () => {
-      const passedMetalMillQuiz: SheetDataTable['rows'][0] = {
-        sheet_id: metalMillSheet.trainingSheetId,
-        sheet_name: metalMillSheet.sheetName,
-        row_index: 0,
-        response_submitted: faker.date.past(),
-        member_number_provided: user.memberNumber,
-        email_provided: user.email,
-        score: 10,
-        max_score: 10,
-        percentage: 100,
-        cached_at: new Date(),
-      };
+      // Whole-second (the events completedAt column is second-precision).
+      const metalMillQuizCompletedAt = DateTime.now()
+        .minus({months: 1})
+        .startOf('second')
+        .toJSDate();
       beforeEach(async () => {
-        await framework.updateTrainingSheetCache(metalCncSheet.trainingSheetId, [
-          passedMetalMillQuiz
-        ]);
+        await framework.commands.trainingQuiz.record({
+          trainingSheetId: metalMillSheet.trainingSheetId as NonEmptyString,
+          completedAt: metalMillQuizCompletedAt,
+          memberNumberProvided: user.memberNumber,
+          emailProvided: user.email,
+          score: 10 as Int,
+          maxScore: 10 as Int,
+          rowHash: faker.string.uuid() as NonEmptyString,
+        });
       });
 
       it('training matrix contains a row for the metal mill', async () => {
@@ -373,7 +371,7 @@ describe('construct-training-matrix', () => {
         expect(millRow.is_trained).toStrictEqual(O.none);
         expect(millRow.is_trainer).toStrictEqual(O.none);
         expect(millRow.equipment_quiz.attempted).toHaveLength(0);
-        expect(millRow.equipment_quiz.passedAt).toStrictEqual([passedMetalMillQuiz.response_submitted]);
+        expect(millRow.equipment_quiz.passedAt).toStrictEqual([metalMillQuizCompletedAt]);
       });
 
       describe('user is marked as trained on the metal mill', () => {
@@ -381,7 +379,7 @@ describe('construct-training-matrix', () => {
           equipmentId: metalMill.id,
           memberNumber: user.memberNumber as Int,
           trainedByMemberNumber: existingTrainerMetalMill.memberNumber as Int,
-          trainedAt: DateTime.fromJSDate(passedMetalMillQuiz.response_submitted).plus(Duration.fromObject({days: 1})).toJSDate(),
+          trainedAt: DateTime.fromJSDate(metalMillQuizCompletedAt).plus(Duration.fromObject({days: 1})).toJSDate(),
         };
 
         beforeEach(async () => {

--- a/tests/read-models/external-state/get-equipment-quiz.test.ts
+++ b/tests/read-models/external-state/get-equipment-quiz.test.ts
@@ -1,4 +1,5 @@
 import {faker} from '@faker-js/faker';
+import {DateTime} from 'luxon';
 import {TestFramework, initTestFramework} from '../test-framework';
 import {NonEmptyString, UUID} from 'io-ts-types';
 
@@ -12,65 +13,57 @@ import {
   getFullQuizResultsForMember,
 } from '../../../src/read-models/external-state/equipment-quiz';
 import {storeSync} from '../../../src/sync-worker/db/store_sync';
-import {SheetDataTable} from '../../../src/sync-worker/google/sheet-data-table';
+
+// The events column is a second-precision timestamp, so seed whole seconds to
+// keep exact-Date assertions stable.
+const recentDate = DateTime.now().minus({months: 1}).startOf('second').toJSDate();
+const oldDate = DateTime.now().minus({months: 18}).startOf('second').toJSDate();
 
 const runGetQuizResultsByEquipment = async (
   framework: TestFramework,
   trainingSheetId: string,
-  equipmentId: UUID,
-): Promise<FullQuizResultsForEquipment> => getRightOrFail(
-  await getFullQuizResultsForEquipment(
-    {
-      sharedReadModel: framework.sharedReadModel,
-      lastQuizSync: framework.lastSync,
-      getSheetData: framework.getSheetData,
-    },
-    trainingSheetId,
-    getSomeOrFail(framework.sharedReadModel.equipment.get(equipmentId))
-  )()
-);
+  equipmentId: UUID
+): Promise<FullQuizResultsForEquipment> =>
+  getRightOrFail(
+    await getFullQuizResultsForEquipment(
+      {
+        sharedReadModel: framework.sharedReadModel,
+        lastQuizSync: framework.lastSync,
+      },
+      trainingSheetId,
+      getSomeOrFail(framework.sharedReadModel.equipment.get(equipmentId))
+    )()
+  );
 
 const runGetQuizResultsByMemberNumber = async (
   framework: TestFramework,
-  memberNumber: number,
-): Promise<FullQuizResultsForMember> => getRightOrFail(
-  await getFullQuizResultsForMember(
-    {
-      sharedReadModel: framework.sharedReadModel,
-      getSheetDataByMemberNumber: framework.getSheetDataByMemberNumber,
-    },
-    memberNumber
-  )()
-);
-
-const populateQuizData = async (
-  framework: TestFramework,
-  syncDate: Date,
-  sheetId: string,
-  entries: SheetDataTable['rows']
-) => {
-  await framework.updateTrainingSheetCache(sheetId, entries);
-  for (const trainingSheetId of new Set(entries.map(m => m.sheet_id))) {
-    getRightOrFail(
-      await storeSync(framework.extDB)(trainingSheetId, syncDate)()
-    );
-  }
-};
+  memberNumber: number
+): Promise<FullQuizResultsForMember> =>
+  getRightOrFail(
+    await getFullQuizResultsForMember(
+      {sharedReadModel: framework.sharedReadModel},
+      memberNumber
+    )()
+  );
 
 describe('Get equipment quiz', () => {
   let framework: TestFramework;
   const addTrainedMember = {
-    memberNumber: faker.number.int() as Int,
+    memberNumber: faker.number.int({max: 100000}) as Int,
     email: faker.internet.email() as EmailAddress,
     name: undefined,
     formOfAddress: undefined,
   };
   const addAwaitingTrainingMember = {
-    memberNumber: faker.number.int({max: 10000}) as Int,
+    memberNumber: faker.number.int({max: 100000}) as Int,
     email: faker.internet.email() as EmailAddress,
     name: undefined,
     formOfAddress: undefined,
   };
+  // A member number recorded on a quiz row but never linked to an account.
+  const unknownMemberNumber = 999999;
+  const unknownMemberEmail = faker.internet.email();
+
   const createArea = {
     id: faker.string.uuid() as UUID,
     name: faker.airline.airport().name as NonEmptyString,
@@ -89,118 +82,164 @@ describe('Get equipment quiz', () => {
     trainingSheetId: 'testTrainingSheetId',
   };
 
+  const recordQuiz = (opts: {
+    completedAt: Date;
+    memberNumber: number | null;
+    email: string | null;
+    score: number;
+    maxScore: number;
+  }) =>
+    framework.commands.trainingQuiz.record({
+      trainingSheetId: addTrainingSheet.trainingSheetId as NonEmptyString,
+      completedAt: opts.completedAt,
+      memberNumberProvided: opts.memberNumber,
+      emailProvided: opts.email,
+      score: opts.score as Int,
+      maxScore: opts.maxScore as Int,
+      rowHash: faker.string.uuid() as NonEmptyString,
+    });
+
+  const quizSyncDate = DateTime.now().startOf('second').toJSDate();
+
   beforeEach(async () => {
     framework = await initTestFramework();
+    await framework.commands.memberNumbers.linkNumberToEmail(addTrainedMember);
+    await framework.commands.memberNumbers.linkNumberToEmail(
+      addAwaitingTrainingMember
+    );
+    await framework.commands.area.create(createArea);
+    await framework.commands.equipment.add(addEquipment);
+    await framework.commands.trainers.markTrained(markTrained);
+    await framework.commands.equipment.trainingSheet(addTrainingSheet);
+
+    // Trained member: passed -> excluded from "awaiting".
+    await recordQuiz({
+      completedAt: recentDate,
+      memberNumber: addTrainedMember.memberNumber,
+      email: addTrainedMember.email,
+      score: 10,
+      maxScore: 10,
+    });
+    // Awaiting member: passed (recent) + a passed row older than 12 months +
+    // a failed attempt.
+    await recordQuiz({
+      completedAt: recentDate,
+      memberNumber: addAwaitingTrainingMember.memberNumber,
+      email: addAwaitingTrainingMember.email,
+      score: 10,
+      maxScore: 10,
+    });
+    await recordQuiz({
+      completedAt: oldDate,
+      memberNumber: addAwaitingTrainingMember.memberNumber,
+      email: addAwaitingTrainingMember.email,
+      score: 10,
+      maxScore: 10,
+    });
+    await recordQuiz({
+      completedAt: recentDate,
+      memberNumber: addAwaitingTrainingMember.memberNumber,
+      email: addAwaitingTrainingMember.email,
+      score: 5,
+      maxScore: 10,
+    });
+    // Unknown member: passed but the member number isn't linked to an account.
+    await recordQuiz({
+      completedAt: recentDate,
+      memberNumber: unknownMemberNumber,
+      email: unknownMemberEmail,
+      score: 10,
+      maxScore: 10,
+    });
+
+    // Only used to populate lastQuizSync (the sheet still syncs).
+    getRightOrFail(
+      await storeSync(framework.extDB)(
+        addTrainingSheet.trainingSheetId,
+        quizSyncDate
+      )()
+    );
   });
+
   afterEach(() => {
     framework.close();
   });
 
-  describe('when equipment has 1 trained member and 1 member awaiting training', () => {
-    let quizSyncDate: Date;
-
-    const trainedMemberQuizAttempt: SheetDataTable["rows"][0] = {
-      sheet_id: addTrainingSheet.trainingSheetId,
-      sheet_name: faker.animal.bear(),
-      row_index: 2, // 1 is the sheet headers.
-      response_submitted: faker.date.past(),
-      member_number_provided: addTrainedMember.memberNumber,
-      email_provided: addTrainedMember.email,
-      score: 10,
-      max_score: 10,
-      percentage: 100,
-      cached_at: new Date(),
-    };
-    const awaitingTrainingMemberQuizAttempt: SheetDataTable["rows"][0] = {
-      sheet_id: addTrainingSheet.trainingSheetId,
-      sheet_name: faker.animal.bear(),
-      row_index: 3,
-      response_submitted: faker.date.past(),
-      member_number_provided: addAwaitingTrainingMember.memberNumber,
-      email_provided: addAwaitingTrainingMember.email,
-      score: 10,
-      max_score: 10,
-      percentage: 100,
-      cached_at: new Date(),
-    };
-
+  describe('getFullQuizResultsForEquipment', () => {
+    let results: FullQuizResultsForEquipment;
     beforeEach(async () => {
-      await framework.commands.memberNumbers.linkNumberToEmail(
-        addTrainedMember
+      results = await runGetQuizResultsByEquipment(
+        framework,
+        addTrainingSheet.trainingSheetId,
+        addTrainingSheet.equipmentId
       );
-      await framework.commands.memberNumbers.linkNumberToEmail(
-        addAwaitingTrainingMember
-      );
-      await framework.commands.area.create(createArea);
-      await framework.commands.equipment.add(addEquipment);
-      await framework.commands.trainers.markTrained(markTrained);
-      await framework.commands.equipment.trainingSheet(addTrainingSheet);
-      quizSyncDate = faker.date.past();
-      await populateQuizData(framework, quizSyncDate, addTrainingSheet.trainingSheetId, [
-        trainedMemberQuizAttempt,
-        awaitingTrainingMemberQuizAttempt
-      ]);
     });
 
-    describe('getFullQuizResultsForEquipment', () => {
-      let quizResultsByEquipment: FullQuizResultsForEquipment;
-      beforeEach(async () => {
-        quizResultsByEquipment = await runGetQuizResultsByEquipment(
-          framework,
-          addTrainingSheet.trainingSheetId,
-          addTrainingSheet.equipmentId
-        );
-      });
-      it('only 1 member appears as awaiting training', () => {
-        expect(
-          quizResultsByEquipment.membersAwaitingTraining.map(m => m.memberNumber)
-        ).toStrictEqual([addAwaitingTrainingMember.memberNumber]);
-      });
-      it('last quiz sync matches expected', () => {
-        expect(getSomeOrFail(quizResultsByEquipment.lastQuizSync)).toStrictEqual(
-          quizSyncDate
-        );
-      });
-
-      it('no failed quizes', () => {
-        expect(quizResultsByEquipment.failedQuizes).toStrictEqual([]);
-      });
-      it('no unknown member passes', () => {
-        expect(quizResultsByEquipment.unknownMembersAwaitingTraining).toStrictEqual([]);
-      });
+    it('shows the linked, untrained member as awaiting training (once - the >12mo pass is windowed out)', () => {
+      expect(results.membersAwaitingTraining.map(m => m.memberNumber)).toStrictEqual(
+        [addAwaitingTrainingMember.memberNumber]
+      );
+      expect(getSomeOrFail(results.lastQuizSync)).toStrictEqual(quizSyncDate);
     });
 
-    describe('quizResultsByMember', () => {
-      let quizResultsForTrainedMember: FullQuizResultsForMember;
-      let quizResultsForMemberAwaitingTraining: FullQuizResultsForMember;
+    it('shows the passed-but-unlinked member as an unknown awaiting pass', () => {
+      expect(results.unknownMembersAwaitingTraining).toHaveLength(1);
+      expect(
+        getSomeOrFail(results.unknownMembersAwaitingTraining[0].memberNumberProvided)
+      ).toBe(unknownMemberNumber);
+      expect(
+        getSomeOrFail(results.unknownMembersAwaitingTraining[0].emailProvided)
+      ).toBe(unknownMemberEmail);
+      expect(results.unknownMembersAwaitingTraining[0].waitingSince).toStrictEqual(
+        recentDate
+      );
+    });
 
-      beforeEach(async () => {
-        quizResultsForTrainedMember = await runGetQuizResultsByMemberNumber(
-          framework,
-          addTrainedMember.memberNumber
-        );
-        quizResultsForMemberAwaitingTraining = await runGetQuizResultsByMemberNumber(
-          framework,
-          addAwaitingTrainingMember.memberNumber
-        );
+    it('reports failed quizes with a computed percentage', () => {
+      expect(results.failedQuizes).toHaveLength(1);
+      expect(results.failedQuizes[0]).toMatchObject({
+        score: 5,
+        maxScore: 10,
+        percentage: 50,
+        completedAt: recentDate,
       });
-      it('shows the trained member as having passed the quiz', () => {
-        expect(quizResultsForTrainedMember.equipmentQuiz[addEquipment.id].passedAt).toStrictEqual(
-          [trainedMemberQuizAttempt.response_submitted]
-        );
-      });
-      it('shows the trained member as having no other quiz attempts', () => {
-        expect(Object.values(quizResultsForTrainedMember.equipmentQuiz)).toHaveLength(1);
-        expect(quizResultsForTrainedMember.equipmentQuiz[addEquipment.id].attempted).toHaveLength(0);
-      });
-      it('shows the member awaiting training as having passed the quiz', () => {
-        expect(quizResultsForMemberAwaitingTraining.equipmentQuiz[addEquipment.id].passedAt).toStrictEqual(
-          [awaitingTrainingMemberQuizAttempt.response_submitted]
-        );
-      });
-      it('shows the member awaiting training as having no other quiz attempts', () => {
-        expect(Object.values(quizResultsForMemberAwaitingTraining.equipmentQuiz)).toHaveLength(1);
-        expect(quizResultsForMemberAwaitingTraining.equipmentQuiz[addEquipment.id].attempted).toHaveLength(0);
+    });
+  });
+
+  describe('getFullQuizResultsForMember', () => {
+    it('shows the trained member as having passed once', async () => {
+      const r = await runGetQuizResultsByMemberNumber(
+        framework,
+        addTrainedMember.memberNumber
+      );
+      expect(r.equipmentQuiz[addEquipment.id].passedAt).toStrictEqual([recentDate]);
+      expect(r.equipmentQuiz[addEquipment.id].attempted).toHaveLength(0);
+    });
+
+    it('is unwindowed - the awaiting member shows both the recent and the >12mo pass', async () => {
+      const r = await runGetQuizResultsByMemberNumber(
+        framework,
+        addAwaitingTrainingMember.memberNumber
+      );
+      const passedAt = r.equipmentQuiz[addEquipment.id].passedAt;
+      expect(passedAt).toHaveLength(2);
+      expect(passedAt.map(d => d.getTime())).toEqual(
+        expect.arrayContaining([recentDate.getTime(), oldDate.getTime()])
+      );
+    });
+
+    it('shows the awaiting member’s failed attempt with score/percentage', async () => {
+      const r = await runGetQuizResultsByMemberNumber(
+        framework,
+        addAwaitingTrainingMember.memberNumber
+      );
+      const attempted = r.equipmentQuiz[addEquipment.id].attempted;
+      expect(attempted).toHaveLength(1);
+      expect(attempted[0]).toMatchObject({
+        score: 5,
+        max_score: 10,
+        percentage: 50,
+        response_submitted: recentDate,
       });
     });
   });


### PR DESCRIPTION
"PR B" of the training-quiz migration (`docs/training-quiz-migration.md`). The equipment/member pages and owner emails still read quiz results from the **Google Sheets cache**; this repoints them at the event-sourced `trainingQuizCompletions` table so the migrated events are actually used. **Pure data-source swap — rendered output is unchanged.**

## What
Everything funnels through two functions in `src/read-models/external-state/equipment-quiz.ts`, so the change is contained:
- **New read-model getters** `trainingQuiz.getCompletionsForSheet(sheetId, since)` (12-month window applied in SQL, `gt`) and `getCompletionsForMember(memberNumber)`, using the table's existing `trainingSheetId` / `memberNumberProvided` indexes.
- **Rewrote** `getFullQuizResultsForEquipment` / `getFullQuizResultsForMember` to read those instead of the sheet cache. All derivation (awaiting = passed − trained; unknown/orphaned; per-equipment grouping) is preserved.
- **`lastQuizSync` kept** — the sheet still syncs, so it stays the "data last refreshed" signal shown on the page.
- Events lack `sheet_name`/`row_index`/`cached_at`/`percentage`, so failed/attempted rows use a minimal event-native shape (`QuizRow`); only the equipment page's *failed-quiz cell* changes field names. **Training-matrix output is untouched** (field names preserved).

## Confirmed decisions (behaviour-preserving)
- **Pass = `score >= maxScore`** (with a `maxScore > 0` guard) — the event equivalent of today's `percentage >= 100`. Percentage is recomputed where displayed.
- **Keep the equipment page's 12-month window**; member page stays unwindowed (as today).
- Pass-mark / window *changes* are explicitly out of scope (separate features).

## Testing
- Rewrote `get-equipment-quiz.test.ts` to seed `TrainingQuizCompleted` events (whole-second dates — the events column is second-precision) instead of the sheet cache; covers passed→awaiting, passed→trained (excluded), passed→unknown member, failed (computed %), the **12-month window** (equipment excludes an old pass), and **member-unwindowed** (still shows it).
- Updated `construct-training-matrix.test.ts` to seed the quiz as an event.
- Full suite green; typecheck / lint / unused-exports clean.

## ⚠️ Deploy ordering
Builds off `main` (the events table/projection landed with #275). But per the migration doc, **deploy this after the one-time backfill has run and the poller (#285) is live**, otherwise the pages show only partially-imported data. It doesn't depend on #276/#285 to compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)